### PR TITLE
Add Firebase analytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ SwiftLintXcode/
 # Auto-gen build files
 node_modules/
 Fitness/API.swift
+Fitness/GoogleService-Info.plist
 schema.json
 # Secrets
 Secrets/

--- a/Fitness.xcodeproj/project.pbxproj
+++ b/Fitness.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		C28801A42293494C00EC48B7 /* HomeViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C28801A32293494C00EC48B7 /* HomeViewController+Extensions.swift */; };
 		C289B16C228A844A00934A2A /* API.swift in Sources */ = {isa = PBXBuildFile; fileRef = C289B16B228A844A00934A2A /* API.swift */; };
 		C289B16E228A9A4700934A2A /* HabitTrackingController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C289B16D228A9A4700934A2A /* HabitTrackingController+Extensions.swift */; };
+		C2B0BE08231E028A0033B8BC /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = C2B0BE07231E028A0033B8BC /* GoogleService-Info.plist */; };
 		C71E8A012091651100542FA3 /* GymFilterCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D26DB0F2072CCA000144BFC /* GymFilterCell.swift */; };
 		C71E8A042091726600542FA3 /* Date+Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71E8A032091726600542FA3 /* Date+Shared.swift */; };
 		C73637282082F170004751F5 /* Gym.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73637272082F170004751F5 /* Gym.swift */; };
@@ -191,6 +192,7 @@
 		C28801A32293494C00EC48B7 /* HomeViewController+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeViewController+Extensions.swift"; sourceTree = "<group>"; };
 		C289B16B228A844A00934A2A /* API.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = API.swift; path = Fitness/API.swift; sourceTree = "<group>"; };
 		C289B16D228A9A4700934A2A /* HabitTrackingController+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HabitTrackingController+Extensions.swift"; sourceTree = "<group>"; };
+		C2B0BE07231E028A0033B8BC /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		C71E8A032091726600542FA3 /* Date+Shared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Shared.swift"; sourceTree = "<group>"; };
 		C73637272082F170004751F5 /* Gym.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Gym.swift; sourceTree = "<group>"; };
 		C73637292082F193004751F5 /* GymClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GymClass.swift; sourceTree = "<group>"; };
@@ -405,6 +407,7 @@
 		C7DFABCD204206E000545B0B /* Fitness */ = {
 			isa = PBXGroup;
 			children = (
+				C2B0BE07231E028A0033B8BC /* GoogleService-Info.plist */,
 				1C7847C3216E77E30066E0DA /* Assets.xcassets */,
 				D94BD3062159DA7D00C9214E /* graphql */,
 				C7DFABCE204206E000545B0B /* AppDelegate.swift */,
@@ -623,6 +626,7 @@
 				C76A70B4205ED2E900E60CC8 /* Montserrat-Medium.ttf in Resources */,
 				C7DFABD9204206E000545B0B /* LaunchScreen.storyboard in Resources */,
 				C76A70AC205EC7B700E60CC8 /* BebasNeue-Regular.ttf in Resources */,
+				C2B0BE08231E028A0033B8BC /* GoogleService-Info.plist in Resources */,
 				8D61D8832162F15900969DF4 /* Montserrat-SemiBold.ttf in Resources */,
 				1C1D28372166E188003FE839 /* Keys.plist in Resources */,
 				1C46740D215FEB1D000AEDF0 /* gymClassInstanceQueries.graphql in Resources */,
@@ -651,9 +655,12 @@
 				"${BUILT_PRODUCTS_DIR}/FLEX/FLEX.framework",
 				"${BUILT_PRODUCTS_DIR}/GTMSessionFetcher/GTMSessionFetcher.framework",
 				"${BUILT_PRODUCTS_DIR}/GoogleToolboxForMac/GoogleToolboxForMac.framework",
+				"${BUILT_PRODUCTS_DIR}/GoogleUtilities/GoogleUtilities.framework",
 				"${BUILT_PRODUCTS_DIR}/Kingfisher/Kingfisher.framework",
 				"${BUILT_PRODUCTS_DIR}/Presentation/Presentation.framework",
 				"${BUILT_PRODUCTS_DIR}/SnapKit/SnapKit.framework",
+				"${BUILT_PRODUCTS_DIR}/SwiftyJSON/SwiftyJSON.framework",
+				"${BUILT_PRODUCTS_DIR}/nanopb/nanopb.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
@@ -666,9 +673,12 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FLEX.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GTMSessionFetcher.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleToolboxForMac.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleUtilities.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Kingfisher.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Presentation.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SnapKit.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SwiftyJSON.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/nanopb.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/Fitness/AppDelegate.swift
+++ b/Fitness/AppDelegate.swift
@@ -8,6 +8,7 @@
 
 import Crashlytics
 import Fabric
+import Firebase
 import GoogleSignIn
 import UIKit
 
@@ -16,7 +17,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {        
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        FirebaseApp.configure()
+
         window = UIWindow(frame: UIScreen.main.bounds)
         window?.makeKeyAndVisible()
         

--- a/Podfile
+++ b/Podfile
@@ -6,7 +6,7 @@ target 'Fitness' do
   use_frameworks!
   pod 'AlamofireImage'
   pod 'Apollo', :git => 'https://github.com/apollographql/apollo-ios.git', :commit => 'b28c3dc'
-  pod 'AppDevAnalytics', :git => 'https://github.com/cuappdev/ios-analytics.git', :commit => '6cc49135579c13c5af72e8e7db12a2bb6e962b4b'
+  pod 'AppDevAnalytics', :git => 'https://github.com/cuappdev/ios-analytics.git'
   pod 'Bartinter'
   pod 'Crashlytics'
   pod 'FLEX', '~> 2.0', :configurations => ['Debug']

--- a/Podfile
+++ b/Podfile
@@ -14,7 +14,7 @@ target 'Fitness' do
   pod 'Firebase/Analytics'
   pod 'GoogleSignIn'
   pod 'Kingfisher', '~> 4.0'
-  pod 'Presentation', :git=> 'https://github.com/cuappdev/Presentation.git'
+  pod 'Presentation', :git=> 'https://github.com/cuappdev/Presentation.git', :commit => 'd4aa2d3ad5901f6ebce0727af592824982f88d13'
   pod 'SnapKit'
   pod 'SwiftLint'
 end

--- a/Podfile
+++ b/Podfile
@@ -6,7 +6,7 @@ target 'Fitness' do
   use_frameworks!
   pod 'AlamofireImage'
   pod 'Apollo', :git => 'https://github.com/apollographql/apollo-ios.git', :commit => 'b28c3dc'
-  pod 'AppDevAnalytics', :git => 'https://github.com/cuappdev/ios-analytics.git'
+  pod 'AppDevAnalytics', :git => 'https://github.com/cuappdev/ios-analytics.git', :commit => '6cc49135579c13c5af72e8e7db12a2bb6e962b4b'
   pod 'Bartinter'
   pod 'Crashlytics'
   pod 'FLEX', '~> 2.0', :configurations => ['Debug']

--- a/Podfile
+++ b/Podfile
@@ -6,10 +6,12 @@ target 'Fitness' do
   use_frameworks!
   pod 'AlamofireImage'
   pod 'Apollo', :git => 'https://github.com/apollographql/apollo-ios.git', :commit => 'b28c3dc'
+  pod 'AppDevAnalytics', :git => 'https://github.com/cuappdev/ios-analytics.git'
   pod 'Bartinter'
   pod 'Crashlytics'
   pod 'FLEX', '~> 2.0', :configurations => ['Debug']
   pod 'Fabric'
+  pod 'Firebase/Analytics'
   pod 'GoogleSignIn'
   pod 'Kingfisher', '~> 4.0'
   pod 'Presentation', :git=> 'https://github.com/cuappdev/Presentation.git'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,9 +5,9 @@ PODS:
   - Apollo (0.9.5):
     - Apollo/Core (= 0.9.5)
   - Apollo/Core (0.9.5)
-  - AppDevAnalytics (0.1.6):
+  - AppDevAnalytics (0.1.7):
     - Crashlytics (~> 3.12)
-    - SwiftyJSON (~> 4.2)
+    - SwiftyJSON (= 4.2)
   - Bartinter (0.0.4)
   - Crashlytics (3.13.0):
     - Fabric (~> 1.10.0)
@@ -82,12 +82,12 @@ PODS:
   - Presentation (4.2.3)
   - SnapKit (5.0.0)
   - SwiftLint (0.32.0)
-  - SwiftyJSON (4.3.0)
+  - SwiftyJSON (4.2.0)
 
 DEPENDENCIES:
   - AlamofireImage
   - Apollo (from `https://github.com/apollographql/apollo-ios.git`, commit `b28c3dc`)
-  - AppDevAnalytics (from `https://github.com/cuappdev/ios-analytics.git`, commit `6cc49135579c13c5af72e8e7db12a2bb6e962b4b`)
+  - AppDevAnalytics (from `https://github.com/cuappdev/ios-analytics.git`)
   - Bartinter
   - Crashlytics
   - Fabric
@@ -127,7 +127,6 @@ EXTERNAL SOURCES:
     :commit: b28c3dc
     :git: https://github.com/apollographql/apollo-ios.git
   AppDevAnalytics:
-    :commit: 6cc49135579c13c5af72e8e7db12a2bb6e962b4b
     :git: https://github.com/cuappdev/ios-analytics.git
   Presentation:
     :commit: d4aa2d3ad5901f6ebce0727af592824982f88d13
@@ -138,7 +137,7 @@ CHECKOUT OPTIONS:
     :commit: b28c3dc
     :git: https://github.com/apollographql/apollo-ios.git
   AppDevAnalytics:
-    :commit: 6cc49135579c13c5af72e8e7db12a2bb6e962b4b
+    :commit: 06d443f7c87c1e7c6f415d1d685debd200b89bf2
     :git: https://github.com/cuappdev/ios-analytics.git
   Presentation:
     :commit: d4aa2d3ad5901f6ebce0727af592824982f88d13
@@ -148,7 +147,7 @@ SPEC CHECKSUMS:
   Alamofire: ae5c501addb7afdbb13687d7f2f722c78734c2d3
   AlamofireImage: 63cfe3baf1370be6c498149687cf6db3e3b00999
   Apollo: 19caf3246d292bbb69ecad1bd098661f78222aba
-  AppDevAnalytics: bec3ab93470f5d1b6d4d55faf3449d14f067e09a
+  AppDevAnalytics: c9547d111f8da5525818ca93dc460405f2fce944
   Bartinter: cfc2ebf2fb8560a7d878dcbdc7d3c667c79090c9
   Crashlytics: 1f5f752c7feac0add0cc1774756f96444fa3b1a7
   Fabric: 09de1e053eb7dc415593166ad3e53d4c88123405
@@ -167,8 +166,8 @@ SPEC CHECKSUMS:
   Presentation: 3c02ab6268b15e44b6146c511686eb9c3f81b7d0
   SnapKit: fd22d10eb9aff484d79a8724eab922c1ddf89bcf
   SwiftLint: 009a898ef2a1c851f45e1b59349bf6ff2ddc990d
-  SwiftyJSON: 6faa0040f8b59dead0ee07436cbf76b73c08fd08
+  SwiftyJSON: c4bcba26dd9ec7a027fc8eade48e2c911f229e96
 
-PODFILE CHECKSUM: bb29c540b0979521e514e03fc8a30ea41d37fef8
+PODFILE CHECKSUM: 403835549813ac0a93bf72e33541f303eff1e454
 
 COCOAPODS: 1.6.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,9 +5,9 @@ PODS:
   - Apollo (0.9.5):
     - Apollo/Core (= 0.9.5)
   - Apollo/Core (0.9.5)
-  - AppDevAnalytics (0.1.5):
+  - AppDevAnalytics (0.1.6):
     - Crashlytics (~> 3.12)
-    - SwiftyJSON
+    - SwiftyJSON (~> 4.2)
   - Bartinter (0.0.4)
   - Crashlytics (3.13.0):
     - Fabric (~> 1.10.0)
@@ -82,12 +82,12 @@ PODS:
   - Presentation (4.2.3)
   - SnapKit (5.0.0)
   - SwiftLint (0.32.0)
-  - SwiftyJSON (5.0.0)
+  - SwiftyJSON (4.3.0)
 
 DEPENDENCIES:
   - AlamofireImage
   - Apollo (from `https://github.com/apollographql/apollo-ios.git`, commit `b28c3dc`)
-  - AppDevAnalytics (from `https://github.com/cuappdev/ios-analytics.git`)
+  - AppDevAnalytics (from `https://github.com/cuappdev/ios-analytics.git`, commit `6cc49135579c13c5af72e8e7db12a2bb6e962b4b`)
   - Bartinter
   - Crashlytics
   - Fabric
@@ -127,6 +127,7 @@ EXTERNAL SOURCES:
     :commit: b28c3dc
     :git: https://github.com/apollographql/apollo-ios.git
   AppDevAnalytics:
+    :commit: 6cc49135579c13c5af72e8e7db12a2bb6e962b4b
     :git: https://github.com/cuappdev/ios-analytics.git
   Presentation:
     :commit: d4aa2d3ad5901f6ebce0727af592824982f88d13
@@ -137,7 +138,7 @@ CHECKOUT OPTIONS:
     :commit: b28c3dc
     :git: https://github.com/apollographql/apollo-ios.git
   AppDevAnalytics:
-    :commit: 0a69032bfa1ef06965036c149e20d14b5bc67db0
+    :commit: 6cc49135579c13c5af72e8e7db12a2bb6e962b4b
     :git: https://github.com/cuappdev/ios-analytics.git
   Presentation:
     :commit: d4aa2d3ad5901f6ebce0727af592824982f88d13
@@ -147,7 +148,7 @@ SPEC CHECKSUMS:
   Alamofire: ae5c501addb7afdbb13687d7f2f722c78734c2d3
   AlamofireImage: 63cfe3baf1370be6c498149687cf6db3e3b00999
   Apollo: 19caf3246d292bbb69ecad1bd098661f78222aba
-  AppDevAnalytics: fdf5b816f9ec815f944173ab4b67b0557ee67a69
+  AppDevAnalytics: bec3ab93470f5d1b6d4d55faf3449d14f067e09a
   Bartinter: cfc2ebf2fb8560a7d878dcbdc7d3c667c79090c9
   Crashlytics: 1f5f752c7feac0add0cc1774756f96444fa3b1a7
   Fabric: 09de1e053eb7dc415593166ad3e53d4c88123405
@@ -166,8 +167,8 @@ SPEC CHECKSUMS:
   Presentation: 3c02ab6268b15e44b6146c511686eb9c3f81b7d0
   SnapKit: fd22d10eb9aff484d79a8724eab922c1ddf89bcf
   SwiftLint: 009a898ef2a1c851f45e1b59349bf6ff2ddc990d
-  SwiftyJSON: 36413e04c44ee145039d332b4f4e2d3e8d6c4db7
+  SwiftyJSON: 6faa0040f8b59dead0ee07436cbf76b73c08fd08
 
-PODFILE CHECKSUM: 403835549813ac0a93bf72e33541f303eff1e454
+PODFILE CHECKSUM: bb29c540b0979521e514e03fc8a30ea41d37fef8
 
 COCOAPODS: 1.6.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -5,11 +5,43 @@ PODS:
   - Apollo (0.9.5):
     - Apollo/Core (= 0.9.5)
   - Apollo/Core (0.9.5)
+  - AppDevAnalytics (0.1.5):
+    - Crashlytics (~> 3.12)
+    - SwiftyJSON
   - Bartinter (0.0.4)
   - Crashlytics (3.13.0):
     - Fabric (~> 1.10.0)
   - Fabric (1.10.0)
+  - Firebase/Analytics (6.1.0):
+    - Firebase/Core
+  - Firebase/Core (6.1.0):
+    - Firebase/CoreOnly
+    - FirebaseAnalytics (= 6.0.1)
+  - Firebase/CoreOnly (6.1.0):
+    - FirebaseCore (= 6.0.1)
+  - FirebaseAnalytics (6.0.1):
+    - FirebaseCore (~> 6.0)
+    - FirebaseInstanceID (~> 4.1)
+    - GoogleAppMeasurement (= 6.0.1)
+    - GoogleUtilities/AppDelegateSwizzler (~> 6.0)
+    - GoogleUtilities/MethodSwizzler (~> 6.0)
+    - GoogleUtilities/Network (~> 6.0)
+    - "GoogleUtilities/NSData+zlib (~> 6.0)"
+    - nanopb (~> 0.3)
+  - FirebaseCore (6.0.1):
+    - GoogleUtilities/Environment (~> 6.0)
+    - GoogleUtilities/Logger (~> 6.0)
+  - FirebaseInstanceID (4.1.0):
+    - FirebaseCore (~> 6.0)
+    - GoogleUtilities/Environment (~> 6.0)
+    - GoogleUtilities/UserDefaults (~> 6.0)
   - FLEX (2.4.0)
+  - GoogleAppMeasurement (6.0.1):
+    - GoogleUtilities/AppDelegateSwizzler (~> 6.0)
+    - GoogleUtilities/MethodSwizzler (~> 6.0)
+    - GoogleUtilities/Network (~> 6.0)
+    - "GoogleUtilities/NSData+zlib (~> 6.0)"
+    - nanopb (~> 0.3)
   - GoogleSignIn (4.4.0):
     - "GoogleToolboxForMac/NSDictionary+URLArguments (~> 2.1)"
     - "GoogleToolboxForMac/NSString+URLArguments (~> 2.1)"
@@ -22,18 +54,44 @@ PODS:
     - GoogleToolboxForMac/Defines (= 2.2.0)
     - "GoogleToolboxForMac/NSString+URLArguments (= 2.2.0)"
   - "GoogleToolboxForMac/NSString+URLArguments (2.2.0)"
+  - GoogleUtilities/AppDelegateSwizzler (6.1.0):
+    - GoogleUtilities/Environment
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Network
+  - GoogleUtilities/Environment (6.1.0)
+  - GoogleUtilities/Logger (6.1.0):
+    - GoogleUtilities/Environment
+  - GoogleUtilities/MethodSwizzler (6.1.0):
+    - GoogleUtilities/Logger
+  - GoogleUtilities/Network (6.1.0):
+    - GoogleUtilities/Logger
+    - "GoogleUtilities/NSData+zlib"
+    - GoogleUtilities/Reachability
+  - "GoogleUtilities/NSData+zlib (6.1.0)"
+  - GoogleUtilities/Reachability (6.1.0):
+    - GoogleUtilities/Logger
+  - GoogleUtilities/UserDefaults (6.1.0):
+    - GoogleUtilities/Logger
   - GTMSessionFetcher/Core (1.2.1)
   - Kingfisher (4.10.1)
+  - nanopb (0.3.901):
+    - nanopb/decode (= 0.3.901)
+    - nanopb/encode (= 0.3.901)
+  - nanopb/decode (0.3.901)
+  - nanopb/encode (0.3.901)
   - Presentation (4.1.2)
   - SnapKit (5.0.0)
   - SwiftLint (0.32.0)
+  - SwiftyJSON (5.0.0)
 
 DEPENDENCIES:
   - AlamofireImage
   - Apollo (from `https://github.com/apollographql/apollo-ios.git`, commit `b28c3dc`)
+  - AppDevAnalytics (from `https://github.com/cuappdev/ios-analytics.git`)
   - Bartinter
   - Crashlytics
   - Fabric
+  - Firebase/Analytics
   - FLEX (~> 2.0)
   - GoogleSignIn
   - Kingfisher (~> 4.0)
@@ -48,18 +106,28 @@ SPEC REPOS:
     - Bartinter
     - Crashlytics
     - Fabric
+    - Firebase
+    - FirebaseAnalytics
+    - FirebaseCore
+    - FirebaseInstanceID
     - FLEX
+    - GoogleAppMeasurement
     - GoogleSignIn
     - GoogleToolboxForMac
+    - GoogleUtilities
     - GTMSessionFetcher
     - Kingfisher
+    - nanopb
     - SnapKit
     - SwiftLint
+    - SwiftyJSON
 
 EXTERNAL SOURCES:
   Apollo:
     :commit: b28c3dc
     :git: https://github.com/apollographql/apollo-ios.git
+  AppDevAnalytics:
+    :git: https://github.com/cuappdev/ios-analytics.git
   Presentation:
     :git: https://github.com/cuappdev/Presentation.git
 
@@ -67,6 +135,9 @@ CHECKOUT OPTIONS:
   Apollo:
     :commit: b28c3dc
     :git: https://github.com/apollographql/apollo-ios.git
+  AppDevAnalytics:
+    :commit: 0a69032bfa1ef06965036c149e20d14b5bc67db0
+    :git: https://github.com/cuappdev/ios-analytics.git
   Presentation:
     :commit: fe68b1b644b6015202430662d4db621eb1b621bc
     :git: https://github.com/cuappdev/Presentation.git
@@ -75,18 +146,27 @@ SPEC CHECKSUMS:
   Alamofire: ae5c501addb7afdbb13687d7f2f722c78734c2d3
   AlamofireImage: 63cfe3baf1370be6c498149687cf6db3e3b00999
   Apollo: 19caf3246d292bbb69ecad1bd098661f78222aba
+  AppDevAnalytics: fdf5b816f9ec815f944173ab4b67b0557ee67a69
   Bartinter: cfc2ebf2fb8560a7d878dcbdc7d3c667c79090c9
   Crashlytics: 1f5f752c7feac0add0cc1774756f96444fa3b1a7
   Fabric: 09de1e053eb7dc415593166ad3e53d4c88123405
+  Firebase: 8d77bb33624ae9b62d745d82ec023de5f70f7e4f
+  FirebaseAnalytics: 629301c2b9925f3537d4093a17a72751ae5b7084
+  FirebaseCore: 66bdef3b310a026880e2a5bc8aa586ab62ce4543
+  FirebaseInstanceID: 27bed93a59b6685f5c3e0c028a878a764fd75c33
   FLEX: bd1a39e55b56bb413b6f1b34b3c10a0dc44ef079
+  GoogleAppMeasurement: 51d8d9ea48f0ca44484d29cfbdef976fbd4fc336
   GoogleSignIn: 7ff245e1a7b26d379099d3243a562f5747e23d39
   GoogleToolboxForMac: ff31605b7d66400dcec09bed5861689aebadda4d
+  GoogleUtilities: 84df567c76ca84f67b7bb40e769fdd4acc746a10
   GTMSessionFetcher: 32aeca0aa144acea523e1c8e053089dec2cb98ca
   Kingfisher: c148cd7b47ebde9989f6bc7c27dcaa79d81279a0
+  nanopb: 2901f78ea1b7b4015c860c2fdd1ea2fee1a18d48
   Presentation: e8571efaa303ed9ce34c2a54d80457f881fd294e
   SnapKit: fd22d10eb9aff484d79a8724eab922c1ddf89bcf
   SwiftLint: 009a898ef2a1c851f45e1b59349bf6ff2ddc990d
+  SwiftyJSON: 36413e04c44ee145039d332b4f4e2d3e8d6c4db7
 
-PODFILE CHECKSUM: f13b28f9e5b97659d322cae568c01afec6734815
+PODFILE CHECKSUM: 70f549b164cdf49d033613d6dce731063622c5fd
 
-COCOAPODS: 1.6.0.beta.1
+COCOAPODS: 1.6.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -79,7 +79,7 @@ PODS:
     - nanopb/encode (= 0.3.901)
   - nanopb/decode (0.3.901)
   - nanopb/encode (0.3.901)
-  - Presentation (4.1.2)
+  - Presentation (4.2.3)
   - SnapKit (5.0.0)
   - SwiftLint (0.32.0)
   - SwiftyJSON (5.0.0)
@@ -95,7 +95,7 @@ DEPENDENCIES:
   - FLEX (~> 2.0)
   - GoogleSignIn
   - Kingfisher (~> 4.0)
-  - Presentation (from `https://github.com/cuappdev/Presentation.git`)
+  - Presentation (from `https://github.com/cuappdev/Presentation.git`, commit `d4aa2d3ad5901f6ebce0727af592824982f88d13`)
   - SnapKit
   - SwiftLint
 
@@ -129,6 +129,7 @@ EXTERNAL SOURCES:
   AppDevAnalytics:
     :git: https://github.com/cuappdev/ios-analytics.git
   Presentation:
+    :commit: d4aa2d3ad5901f6ebce0727af592824982f88d13
     :git: https://github.com/cuappdev/Presentation.git
 
 CHECKOUT OPTIONS:
@@ -139,6 +140,7 @@ CHECKOUT OPTIONS:
     :commit: 0a69032bfa1ef06965036c149e20d14b5bc67db0
     :git: https://github.com/cuappdev/ios-analytics.git
   Presentation:
+    :commit: d4aa2d3ad5901f6ebce0727af592824982f88d13
     :git: https://github.com/cuappdev/Presentation.git
 
 SPEC CHECKSUMS:
@@ -161,11 +163,11 @@ SPEC CHECKSUMS:
   GTMSessionFetcher: 32aeca0aa144acea523e1c8e053089dec2cb98ca
   Kingfisher: c148cd7b47ebde9989f6bc7c27dcaa79d81279a0
   nanopb: 2901f78ea1b7b4015c860c2fdd1ea2fee1a18d48
-  Presentation: e8571efaa303ed9ce34c2a54d80457f881fd294e
+  Presentation: 3c02ab6268b15e44b6146c511686eb9c3f81b7d0
   SnapKit: fd22d10eb9aff484d79a8724eab922c1ddf89bcf
   SwiftLint: 009a898ef2a1c851f45e1b59349bf6ff2ddc990d
   SwiftyJSON: 36413e04c44ee145039d332b4f4e2d3e8d6c4db7
 
-PODFILE CHECKSUM: 70f549b164cdf49d033613d6dce731063622c5fd
+PODFILE CHECKSUM: 403835549813ac0a93bf72e33541f303eff1e454
 
 COCOAPODS: 1.6.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -139,7 +139,6 @@ CHECKOUT OPTIONS:
     :commit: 0a69032bfa1ef06965036c149e20d14b5bc67db0
     :git: https://github.com/cuappdev/ios-analytics.git
   Presentation:
-    :commit: fe68b1b644b6015202430662d4db621eb1b621bc
     :git: https://github.com/cuappdev/Presentation.git
 
 SPEC CHECKSUMS:


### PR DESCRIPTION
Issue: #134 
Overview: This PR does setup to incorporate Firebase Analytics for Eatery. It also adds a new AppDevAnalytics cocoapod which contains some nice classes to use when logging.

Test:
![Screen Shot 2019-09-02 at 10 10 43 PM](https://user-images.githubusercontent.com/26048121/64139490-0c4fee00-cdcf-11e9-9366-8a1e01d4a062.png)


NOTE: I will post the `GoogleService-Info.plist` in #uplift-ios. You will need this for Firebase to run properly