### PR TITLE
Fix hours data staying dropped after leaving GymDetailVC

### DIFF
--- a/Uplift.xcodeproj/project.pbxproj
+++ b/Uplift.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		8DD7C7752083E0FB004EB196 /* DropdownViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DD7C7742083E0FB004EB196 /* DropdownViewCell.swift */; };
 		8DD7C77720844175004EB196 /* DropdownFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DD7C77620844175004EB196 /* DropdownFooterView.swift */; };
 		AE6DB9E165B20CBD98F42FC8 /* Pods_Uplift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 48695D922CD490E026211F06 /* Pods_Uplift.framework */; };
+		C218F937233DBE080018838A /* GymDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = C218F936233DBE080018838A /* GymDetail.swift */; };
 		C21BE14B229212AA00B5D219 /* ClassListHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21BE14A229212AA00B5D219 /* ClassListHeaderView.swift */; };
 		C21BE14D2292374400B5D219 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21BE14C2292374400B5D219 /* HomeViewController.swift */; };
 		C21BE1502292409D00B5D219 /* CheckInsListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21BE14F2292409D00B5D219 /* CheckInsListCell.swift */; };
@@ -181,6 +182,7 @@
 		8DD7C7722083E09A004EB196 /* DropdownHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropdownHeaderView.swift; sourceTree = "<group>"; };
 		8DD7C7742083E0FB004EB196 /* DropdownViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropdownViewCell.swift; sourceTree = "<group>"; };
 		8DD7C77620844175004EB196 /* DropdownFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropdownFooterView.swift; sourceTree = "<group>"; };
+		C218F936233DBE080018838A /* GymDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GymDetail.swift; sourceTree = "<group>"; };
 		C21BE14A229212AA00B5D219 /* ClassListHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClassListHeaderView.swift; sourceTree = "<group>"; };
 		C21BE14C2292374400B5D219 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		C21BE14F2292409D00B5D219 /* CheckInsListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckInsListCell.swift; sourceTree = "<group>"; };
@@ -382,6 +384,7 @@
 				C76F715E20900AD400FDC958 /* Tag.swift */,
 				4F27D7F822445BDD00135DC4 /* User.swift */,
 				8DD74F352242A2DA00CE1274 /* Habit.swift */,
+				C218F936233DBE080018838A /* GymDetail.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -933,6 +936,7 @@
 				C28801A222933BBC00EC48B7 /* TodaysClassListItemCell.swift in Sources */,
 				C21BE1522292421200B5D219 /* ListCollectionViewCell.swift in Sources */,
 				7E3667C7232DA39D00C5971E /* OldGymDetailViewController.swift in Sources */,
+				C218F937233DBE080018838A /* GymDetail.swift in Sources */,
 				E604DC3A233B1DF7003598BC /* ProRoutine.swift in Sources */,
 				C7ABE48F2069BF1A0042CFA7 /* CalendarCell.swift in Sources */,
 				7E9D6DF322961E000054F710 /* GymDetailPopularTimesCell.swift in Sources */,

--- a/Uplift/Controllers/GymDetailViewController+Extensions.swift
+++ b/Uplift/Controllers/GymDetailViewController+Extensions.swift
@@ -11,7 +11,7 @@ import UIKit
 extension GymDetailViewController: GymDetailHoursCellDelegate {
     
     func didDropHours(isDropped: Bool, completion: @escaping () -> Void) {
-        hoursIsDropped.toggle()
+        gymDetail.hoursDataIsDropped.toggle()
         collectionView.performBatchUpdates({}, completion: nil)
         completion()
     }

--- a/Uplift/Controllers/GymDetailViewController.swift
+++ b/Uplift/Controllers/GymDetailViewController.swift
@@ -18,12 +18,11 @@ class GymDetailViewController: UIViewController {
     let collectionView = UICollectionView(frame: .zero, collectionViewLayout: StretchyHeaderLayout())
 
     // MARK: - Private data vars
-    private var gym: Gym!
     private var sections: [Section] = []
     private var todaysClasses: [GymClassInstance] = []
 
     // MARK: - Public data vars
-    var hoursIsDropped: Bool = false
+    var gymDetail: GymDetail!
 
     private enum Constants {
         static let gymDetailClassesCellIdentifier = "gymDetailClassesCellIdentifier"
@@ -48,7 +47,7 @@ class GymDetailViewController: UIViewController {
     // MARK: - Custom Initializer
     init(gym: Gym) {
         super.init(nibName: nil, bundle: nil)
-        self.gym = gym
+        self.gymDetail = GymDetail(gym: gym)
 
         if gym.isOpen {
             self.sections = [
@@ -79,7 +78,7 @@ class GymDetailViewController: UIViewController {
 
         setupViews()
 
-        NetworkManager.shared.getClassInstancesByGym(gymId: gym.id, date: Date.getNowString()) { gymClasses in
+        NetworkManager.shared.getClassInstancesByGym(gymId: gymDetail.gym.id, date: Date.getNowString()) { gymClasses in
             self.todaysClasses = gymClasses
             let items = self.sections[0].items
             self.sections[0].items[items.count - 1] = .classes(gymClasses)
@@ -125,17 +124,17 @@ extension GymDetailViewController: UICollectionViewDataSource, UICollectionViewD
         case .hours:
             // swiftlint:disable:next force_cast
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Constants.gymDetailHoursCellIdentifier, for: indexPath) as! GymDetailHoursCell
-             cell.configure(for: self, gym: gym)
+            cell.configure(for: self, gymDetail: gymDetail)
             return cell
         case .busyTimes:
             // swiftlint:disable:next force_cast
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Constants.gymDetailPopularTimesCellIdentifier, for: indexPath) as! GymDetailPopularTimesCell
-            cell.configure(for: gym)
+            cell.configure(for: gymDetail.gym)
             return cell
         case .facilities:
             // swiftlint:disable:next force_cast
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Constants.gymDetailFacilitiesCellIdentifier, for: indexPath) as! GymDetailFacilitiesCell
-             cell.configure(for: gym)
+            cell.configure(for: gymDetail.gym)
             return cell
         case .classes:
             // swiftlint:disable:next force_cast
@@ -151,7 +150,22 @@ extension GymDetailViewController: UICollectionViewDataSource, UICollectionViewD
 
         switch itemType {
         case .hours:
-            return CGSize(width: width, height: GymDetailHoursCell.baseHeight)
+            let dividerHeight = 1
+            let dividerTopPadding = 32
+            let hoursTableViewDroppedHeight = 181
+            let hoursTableViewHeight = 19
+            let hoursTableViewTopPadding = 12
+            let hoursTitleLabelHeight = 19
+            let hoursTitleLabelTopPadding = 36
+            var height = CGFloat(hoursTitleLabelTopPadding +
+                hoursTitleLabelHeight +
+                hoursTableViewTopPadding +
+                dividerTopPadding +
+                dividerHeight)
+            height = gymDetail.hoursDataIsDropped
+                ? height + CGFloat(hoursTableViewDroppedHeight)
+                : height + CGFloat(hoursTableViewHeight)
+            return CGSize(width: width, height: height)
         case .busyTimes:
             return CGSize(width: width, height: GymDetailPopularTimesCell.baseHeight)
         case.facilities:
@@ -175,7 +189,7 @@ extension GymDetailViewController: UICollectionViewDataSource, UICollectionViewD
             withReuseIdentifier: Constants.gymDetailHeaderViewIdentifier,
             // swiftlint:disable:next force_cast
             for: indexPath) as! GymDetailHeaderView
-        headerView.configure(for: gym)
+        headerView.configure(for: gymDetail.gym)
         return headerView
     }
 

--- a/Uplift/Controllers/GymDetailViewController.swift
+++ b/Uplift/Controllers/GymDetailViewController.swift
@@ -150,21 +150,14 @@ extension GymDetailViewController: UICollectionViewDataSource, UICollectionViewD
 
         switch itemType {
         case .hours:
-            let dividerHeight = 1
-            let dividerTopPadding = 32
-            let hoursTableViewDroppedHeight = 181
-            let hoursTableViewHeight = 19
-            let hoursTableViewTopPadding = 12
-            let hoursTitleLabelHeight = 19
-            let hoursTitleLabelTopPadding = 36
-            var height = CGFloat(hoursTitleLabelTopPadding +
-                hoursTitleLabelHeight +
-                hoursTableViewTopPadding +
-                dividerTopPadding +
-                dividerHeight)
-            height = gymDetail.hoursDataIsDropped
-                ? height + CGFloat(hoursTableViewDroppedHeight)
-                : height + CGFloat(hoursTableViewHeight)
+            let baseHeight = CGFloat(GymDetailHoursCell.Constants.hoursTitleLabelTopPadding +
+                GymDetailHoursCell.Constants.hoursTitleLabelHeight +
+                GymDetailHoursCell.Constants.hoursTableViewTopPadding +
+                GymDetailHoursCell.Constants.dividerTopPadding +
+                GymDetailHoursCell.Constants.dividerHeight)
+            let height = gymDetail.hoursDataIsDropped
+                ? baseHeight + CGFloat(GymDetailHoursCell.Constants.hoursTableViewDroppedHeight)
+                : baseHeight + CGFloat(GymDetailHoursCell.Constants.hoursTableViewHeight)
             return CGSize(width: width, height: height)
         case .busyTimes:
             return CGSize(width: width, height: GymDetailPopularTimesCell.baseHeight)

--- a/Uplift/Models/Gym.swift
+++ b/Uplift/Models/Gym.swift
@@ -35,7 +35,7 @@ struct Gym {
     init(gymData: AllGymsQuery.Data.Gym ) {
         id = gymData.id
         name = gymData.name
-        // TODO : fetch equipment once it's availble from backend
+        // TODO : fetch equipment once it's available from backend
         equipment = ""
         imageURL = URL(string: gymData.imageUrl ?? "")
 
@@ -64,7 +64,7 @@ struct Gym {
     init(gymData: GymByIdQuery.Data.Gym ) {
         id = gymData.id
         name = gymData.name
-        // TODO : fetch equipment once it's availble from backend
+        // TODO : fetch equipment once it's available from backend
         equipment = ""
         imageURL = URL(string: gymData.imageUrl ?? "")
 

--- a/Uplift/Models/GymDetail.swift
+++ b/Uplift/Models/GymDetail.swift
@@ -1,0 +1,21 @@
+//
+//  GymDetail.swift
+//  Uplift
+//
+//  Created by Kevin Chan on 9/26/19.
+//  Copyright © 2019 Cornell AppDev. All rights reserved.
+//
+
+import Foundation
+
+struct GymDetail {
+
+    let gym: Gym
+    var hoursDataIsDropped: Bool
+
+    init(gym: Gym) {
+        self.gym = gym
+        self.hoursDataIsDropped = false
+    }
+
+}

--- a/Uplift/Views/GymDetail/GymDetailHoursCell.swift
+++ b/Uplift/Views/GymDetail/GymDetailHoursCell.swift
@@ -25,25 +25,6 @@ class GymDetailHoursCell: UICollectionViewCell {
         static let hoursTitleLabelTopPadding = 36
     }
 
-    // MARK: - Public data vars
-    static var baseHeight: CGFloat {
-        var height = Constants.hoursTitleLabelTopPadding +
-            Constants.hoursTitleLabelHeight +
-            Constants.hoursTableViewTopPadding +
-            Constants.dividerTopPadding +
-            Constants.dividerHeight
-        height = hoursData.isDropped
-            ? height + Constants.hoursTableViewDroppedHeight
-            : height + Constants.hoursTableViewHeight
-        return CGFloat(height)
-    }
-
-    // MARK: - Private structs/classes
-    private struct HoursData {
-        var data: [String]!
-        var isDropped: Bool!
-    }
-
     // MARK: - Private data vars
     private enum Days {
         case sunday
@@ -58,7 +39,7 @@ class GymDetailHoursCell: UICollectionViewCell {
     private let days: [Days] = [.sunday, .monday, .tuesday, .wednesday, .thursday, .friday, .saturday]
     private weak var delegate: GymDetailHoursCellDelegate?
     private var hours: [DailyGymHours] = []
-    private static var hoursData = HoursData(data: [], isDropped: false)
+    private var hoursDataIsDropped = false
     private var hoursToday: DailyGymHours!
     private var isOpen: Bool = true
 
@@ -80,7 +61,9 @@ class GymDetailHoursCell: UICollectionViewCell {
     }
 
     // MARK: - Public configure
-    func configure(for delegate: GymDetailHoursCellDelegate, gym: Gym) {
+    func configure(for delegate: GymDetailHoursCellDelegate, gymDetail: GymDetail) {
+        let gym = gymDetail.gym
+        self.hoursDataIsDropped = gymDetail.hoursDataIsDropped
         self.delegate = delegate
         self.hours = gym.gymHours
         self.hoursToday = gym.gymHoursToday
@@ -137,7 +120,7 @@ class GymDetailHoursCell: UICollectionViewCell {
             if hours.isEmpty || hoursToday == nil {
                 make.height.equalTo(0)
             } else {
-                if GymDetailHoursCell.hoursData.isDropped {
+                if hoursDataIsDropped {
                     make.height.equalTo(Constants.hoursTableViewDroppedHeight)
                 } else {
                     make.height.equalTo(Constants.hoursTableViewHeight)
@@ -171,8 +154,8 @@ class GymDetailHoursCell: UICollectionViewCell {
             modifiedIndices.append(IndexPath(row: i, section: 0))
         }
 
-        if GymDetailHoursCell.hoursData.isDropped { // collapsing details
-            GymDetailHoursCell.hoursData.isDropped = false
+        if hoursDataIsDropped { // collapsing details
+            hoursDataIsDropped = false
             hoursTableView.deleteRows(at: modifiedIndices, with: .fade)
             // swiftlint:disable:next force_cast
             (hoursTableView.headerView(forSection: 0) as! GymHoursHeaderView).downArrow.image = .none
@@ -186,7 +169,7 @@ class GymDetailHoursCell: UICollectionViewCell {
                 }
             }
         } else { // expanding details
-            GymDetailHoursCell.hoursData.isDropped = true
+            hoursDataIsDropped = true
             hoursTableView.insertRows(at: modifiedIndices, with: .fade)
             // swiftlint:disable:next force_cast
             (hoursTableView.headerView(forSection: 0) as! GymHoursHeaderView).downArrow.image = UIImage(named: "down-arrow-solid")
@@ -207,7 +190,7 @@ class GymDetailHoursCell: UICollectionViewCell {
 extension GymDetailHoursCell: UITableViewDelegate, UITableViewDataSource {
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        let numRows = GymDetailHoursCell.hoursData.isDropped ? 6 : 0
+        let numRows = hoursDataIsDropped ? 6 : 0
         return numRows
     }
 
@@ -256,7 +239,7 @@ extension GymDetailHoursCell: UITableViewDelegate, UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        let height: CGFloat = GymDetailHoursCell.hoursData.isDropped ? 27 : 19
+        let height: CGFloat = hoursDataIsDropped ? 27 : 19
         return height
     }
 }

--- a/Uplift/Views/GymDetail/GymDetailHoursCell.swift
+++ b/Uplift/Views/GymDetail/GymDetailHoursCell.swift
@@ -15,7 +15,7 @@ protocol GymDetailHoursCellDelegate: class {
 class GymDetailHoursCell: UICollectionViewCell {
 
     // MARK: - Constraint constants
-    private enum Constants {
+    enum Constants {
         static let dividerHeight = 1
         static let dividerTopPadding = 32
         static let hoursTableViewDroppedHeight = 181


### PR DESCRIPTION
This PR fixes the bug where if you go into a `GymDetailViewController` -> go to Hours section -> Dropdown the Hours data -> go back to home screen -> Go into `GymDetailViewController` again, the hours data would already be dropped.

The reason for this is because we were using `static vars` to determine when the `hoursData` was dropped or not. This PR fixes it by making it a property of a new `GymDetail` model which just contains a `gym` and `hoursDataIsDropped` field.

`NOTE:` Demo video in `#uplift-ios`