### PR TITLE
Fix GymDetail facilities bug

### DIFF
--- a/Uplift/Controllers/GymDetailViewController+Extensions.swift
+++ b/Uplift/Controllers/GymDetailViewController+Extensions.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 extension GymDetailViewController: GymDetailHoursCellDelegate {
-    
+
     func didDropHours(isDropped: Bool, completion: @escaping () -> Void) {
         gymDetail.hoursDataIsDropped.toggle()
         collectionView.performBatchUpdates({}, completion: nil)

--- a/Uplift/Controllers/GymDetailViewController.swift
+++ b/Uplift/Controllers/GymDetailViewController.swift
@@ -150,42 +150,13 @@ extension GymDetailViewController: UICollectionViewDataSource, UICollectionViewD
 
         switch itemType {
         case .hours:
-            let baseHeight = CGFloat(GymDetailHoursCell.Constants.hoursTitleLabelTopPadding +
-                GymDetailHoursCell.Constants.hoursTitleLabelHeight +
-                GymDetailHoursCell.Constants.hoursTableViewTopPadding +
-                GymDetailHoursCell.Constants.dividerTopPadding +
-                GymDetailHoursCell.Constants.dividerHeight)
-            let height = gymDetail.hoursDataIsDropped
-                ? baseHeight + CGFloat(GymDetailHoursCell.Constants.hoursTableViewDroppedHeight)
-                : baseHeight + CGFloat(GymDetailHoursCell.Constants.hoursTableViewHeight)
-            return CGSize(width: width, height: height)
+            return CGSize(width: width, height: hoursHeight())
         case .busyTimes:
-            let height = CGFloat(GymDetailPopularTimesCell.Constants.popularTimesLabelTopPadding +
-                GymDetailPopularTimesCell.Constants.popularTimesLabelHeight +
-                GymDetailPopularTimesCell.Constants.popularTimesHistogramTopPadding +
-                GymDetailPopularTimesCell.Constants.popularTimesHistogramHeight +
-                GymDetailPopularTimesCell.Constants.dividerViewTopPadding +
-                GymDetailPopularTimesCell.Constants.dividerViewHeight)
-            return CGSize(width: width, height: height)
+            return CGSize(width: width, height: busyTimesHeight())
         case.facilities:
-            let baseHeight = CGFloat(GymDetailFacilitiesCell.Constants.facilitiesLabelTopPadding +
-                GymDetailFacilitiesCell.Constants.facilitiesLabelHeight +
-                GymDetailFacilitiesCell.Constants.gymFacilitiesTopPadding +
-                GymDetailFacilitiesCell.Constants.dividerTopPadding +
-                GymDetailFacilitiesCell.Constants.dividerHeight)
-            let tableViewHeight = GymDetailFacilitiesCell.Constants.gymFacilitiesCellHeight *
-                    CGFloat(gymDetail.facilities.count)
-            return CGSize(width: width, height: baseHeight + tableViewHeight)
+            return CGSize(width: width, height: facilitiesHeight())
         case.classes:
-            let baseHeight = CGFloat(GymDetailTodaysClassesCell.Constants.todaysClassesLabelTopPadding +
-                GymDetailTodaysClassesCell.Constants.todaysClassesLabelHeight)
-            return (todaysClasses.isEmpty) ?
-                CGSize(width: width, height: baseHeight + GymDetailTodaysClassesCell.Constants.noMoreClassesLabelTopPadding +
-                    GymDetailTodaysClassesCell.Constants.noMoreClassesLabelHeight +
-                    GymDetailTodaysClassesCell.Constants.noMoreClassesLabelBottomPadding)
-                : CGSize(width: width, height: baseHeight +
-                    (2.0 * GymDetailTodaysClassesCell.Constants.classesCollectionViewVerticalPadding) +
-                    classesCollectionViewHeight())
+            return CGSize(width: width, height: todaysClassesHeight())
         }
     }
 
@@ -247,6 +218,63 @@ extension GymDetailViewController {
             make.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(backButtonTopPadding)
             make.size.equalTo(backButtonSize)
         }
+    }
+}
+
+// MARK: - Item Height Calculations
+extension GymDetailViewController {
+    enum ConstraintConstants {
+        static let dividerHeight = 1
+        static let dividerViewTopPadding = 24
+        static let popularTimesHistogramTopPadding = 24
+        static let noMoreClassesLabelBottomPadding: CGFloat = 57
+    }
+
+    func hoursHeight() -> CGFloat {
+        let baseHeight = CGFloat(GymDetailHoursCell.Constants.hoursTitleLabelTopPadding +
+            GymDetailHoursCell.Constants.hoursTitleLabelHeight +
+            GymDetailHoursCell.Constants.hoursTableViewTopPadding +
+            GymDetailHoursCell.Constants.dividerTopPadding +
+            ConstraintConstants.dividerHeight)
+        let height = gymDetail.hoursDataIsDropped
+            ? baseHeight + CGFloat(GymDetailHoursCell.Constants.hoursTableViewDroppedHeight)
+            : baseHeight + CGFloat(GymDetailHoursCell.Constants.hoursTableViewHeight)
+        return height
+    }
+
+    func busyTimesHeight() -> CGFloat {
+        let labelHeight = GymDetailPopularTimesCell.Constants.popularTimesLabelTopPadding +
+        GymDetailPopularTimesCell.Constants.popularTimesLabelHeight
+
+        let histogramHeight = ConstraintConstants.popularTimesHistogramTopPadding +
+        GymDetailPopularTimesCell.Constants.popularTimesHistogramHeight
+
+        let dividerHeight = ConstraintConstants.dividerViewTopPadding +
+        ConstraintConstants.dividerHeight
+
+        return CGFloat(labelHeight + histogramHeight + dividerHeight)
+    }
+
+    func facilitiesHeight() -> CGFloat {
+        let baseHeight = CGFloat(GymDetailFacilitiesCell.Constants.facilitiesLabelTopPadding +
+            GymDetailFacilitiesCell.Constants.facilitiesLabelHeight +
+            GymDetailFacilitiesCell.Constants.gymFacilitiesTopPadding +
+            ConstraintConstants.dividerViewTopPadding +
+            ConstraintConstants.dividerHeight)
+        let tableViewHeight = GymDetailFacilitiesCell.Constants.gymFacilitiesCellHeight *
+                CGFloat(gymDetail.facilities.count)
+        return baseHeight + tableViewHeight
+    }
+
+    func todaysClassesHeight() -> CGFloat {
+        let baseHeight = CGFloat(GymDetailTodaysClassesCell.Constants.todaysClassesLabelTopPadding +
+            GymDetailTodaysClassesCell.Constants.todaysClassesLabelHeight)
+        return (todaysClasses.isEmpty) ? baseHeight + GymDetailTodaysClassesCell.Constants.noMoreClassesLabelTopPadding +
+            GymDetailTodaysClassesCell.Constants.noMoreClassesLabelHeight +
+            ConstraintConstants.noMoreClassesLabelBottomPadding
+            : baseHeight + (2.0 *
+                GymDetailTodaysClassesCell.Constants.classesCollectionViewVerticalPadding) +
+                classesCollectionViewHeight()
     }
 }
 

--- a/Uplift/Controllers/GymDetailViewController.swift
+++ b/Uplift/Controllers/GymDetailViewController.swift
@@ -150,13 +150,13 @@ extension GymDetailViewController: UICollectionViewDataSource, UICollectionViewD
 
         switch itemType {
         case .hours:
-            return CGSize(width: width, height: hoursHeight())
+            return CGSize(width: width, height: getHoursHeight())
         case .busyTimes:
-            return CGSize(width: width, height: busyTimesHeight())
+            return CGSize(width: width, height: getBusyTimesHeight())
         case.facilities:
-            return CGSize(width: width, height: facilitiesHeight())
+            return CGSize(width: width, height: getFacilitiesHeight())
         case.classes:
-            return CGSize(width: width, height: todaysClassesHeight())
+            return CGSize(width: width, height: getTodaysClassesHeight())
         }
     }
 
@@ -230,7 +230,7 @@ extension GymDetailViewController {
         static let noMoreClassesLabelBottomPadding: CGFloat = 57
     }
 
-    func hoursHeight() -> CGFloat {
+    func getHoursHeight() -> CGFloat {
         let baseHeight = CGFloat(GymDetailHoursCell.Constants.hoursTitleLabelTopPadding +
             GymDetailHoursCell.Constants.hoursTitleLabelHeight +
             GymDetailHoursCell.Constants.hoursTableViewTopPadding +
@@ -242,7 +242,7 @@ extension GymDetailViewController {
         return height
     }
 
-    func busyTimesHeight() -> CGFloat {
+    func getBusyTimesHeight() -> CGFloat {
         let labelHeight = GymDetailPopularTimesCell.Constants.popularTimesLabelTopPadding +
         GymDetailPopularTimesCell.Constants.popularTimesLabelHeight
 
@@ -255,7 +255,7 @@ extension GymDetailViewController {
         return CGFloat(labelHeight + histogramHeight + dividerHeight)
     }
 
-    func facilitiesHeight() -> CGFloat {
+    func getFacilitiesHeight() -> CGFloat {
         let baseHeight = CGFloat(GymDetailFacilitiesCell.Constants.facilitiesLabelTopPadding +
             GymDetailFacilitiesCell.Constants.facilitiesLabelHeight +
             GymDetailFacilitiesCell.Constants.gymFacilitiesTopPadding +
@@ -266,15 +266,16 @@ extension GymDetailViewController {
         return baseHeight + tableViewHeight
     }
 
-    func todaysClassesHeight() -> CGFloat {
+    func getTodaysClassesHeight() -> CGFloat {
         let baseHeight = CGFloat(GymDetailTodaysClassesCell.Constants.todaysClassesLabelTopPadding +
             GymDetailTodaysClassesCell.Constants.todaysClassesLabelHeight)
-        return (todaysClasses.isEmpty) ? baseHeight + GymDetailTodaysClassesCell.Constants.noMoreClassesLabelTopPadding +
+        let noMoreClassesHeight = GymDetailTodaysClassesCell.Constants.noMoreClassesLabelTopPadding +
             GymDetailTodaysClassesCell.Constants.noMoreClassesLabelHeight +
             ConstraintConstants.noMoreClassesLabelBottomPadding
-            : baseHeight + (2.0 *
-                GymDetailTodaysClassesCell.Constants.classesCollectionViewVerticalPadding) +
-                classesCollectionViewHeight()
+        let collectionViewHeight = 2.0 * GymDetailTodaysClassesCell.Constants.classesCollectionViewVerticalPadding +
+            classesCollectionViewHeight()
+
+        return (todaysClasses.isEmpty) ? baseHeight + noMoreClassesHeight : baseHeight + collectionViewHeight
     }
 }
 

--- a/Uplift/Controllers/GymDetailViewController.swift
+++ b/Uplift/Controllers/GymDetailViewController.swift
@@ -134,7 +134,7 @@ extension GymDetailViewController: UICollectionViewDataSource, UICollectionViewD
         case .facilities:
             // swiftlint:disable:next force_cast
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: Constants.gymDetailFacilitiesCellIdentifier, for: indexPath) as! GymDetailFacilitiesCell
-            cell.configure(for: gymDetail.gym)
+            cell.configure(for: gymDetail)
             return cell
         case .classes:
             // swiftlint:disable:next force_cast
@@ -150,11 +150,7 @@ extension GymDetailViewController: UICollectionViewDataSource, UICollectionViewD
 
         switch itemType {
         case .hours:
-            let baseHeight = CGFloat(GymDetailHoursCell.Constants.hoursTitleLabelTopPadding +
-                GymDetailHoursCell.Constants.hoursTitleLabelHeight +
-                GymDetailHoursCell.Constants.hoursTableViewTopPadding +
-                GymDetailHoursCell.Constants.dividerTopPadding +
-                GymDetailHoursCell.Constants.dividerHeight)
+            let baseHeight = GymDetailHoursCell.baseHeight
             let height = gymDetail.hoursDataIsDropped
                 ? baseHeight + CGFloat(GymDetailHoursCell.Constants.hoursTableViewDroppedHeight)
                 : baseHeight + CGFloat(GymDetailHoursCell.Constants.hoursTableViewHeight)
@@ -162,7 +158,7 @@ extension GymDetailViewController: UICollectionViewDataSource, UICollectionViewD
         case .busyTimes:
             return CGSize(width: width, height: GymDetailPopularTimesCell.baseHeight)
         case.facilities:
-            let tableViewHeight = GymDetailFacilitiesCell.Constants.gymFacilitiesCellHeight * CGFloat(GymDetailFacilitiesCell.gymFacilitiesCount)
+            let tableViewHeight = GymDetailFacilitiesCell.Constants.gymFacilitiesCellHeight * CGFloat(gymDetail.facilities.count)
             return CGSize(width: width, height: GymDetailFacilitiesCell.baseHeight + tableViewHeight)
         case.classes:
             return (todaysClasses.isEmpty) ?

--- a/Uplift/Controllers/GymDetailViewController.swift
+++ b/Uplift/Controllers/GymDetailViewController.swift
@@ -150,23 +150,40 @@ extension GymDetailViewController: UICollectionViewDataSource, UICollectionViewD
 
         switch itemType {
         case .hours:
-            let baseHeight = GymDetailHoursCell.baseHeight
+            let baseHeight = CGFloat(GymDetailHoursCell.Constants.hoursTitleLabelTopPadding +
+                GymDetailHoursCell.Constants.hoursTitleLabelHeight +
+                GymDetailHoursCell.Constants.hoursTableViewTopPadding +
+                GymDetailHoursCell.Constants.dividerTopPadding +
+                GymDetailHoursCell.Constants.dividerHeight)
             let height = gymDetail.hoursDataIsDropped
                 ? baseHeight + CGFloat(GymDetailHoursCell.Constants.hoursTableViewDroppedHeight)
                 : baseHeight + CGFloat(GymDetailHoursCell.Constants.hoursTableViewHeight)
             return CGSize(width: width, height: height)
         case .busyTimes:
-            return CGSize(width: width, height: GymDetailPopularTimesCell.baseHeight)
+            let height = CGFloat(GymDetailPopularTimesCell.Constants.popularTimesLabelTopPadding +
+                GymDetailPopularTimesCell.Constants.popularTimesLabelHeight +
+                GymDetailPopularTimesCell.Constants.popularTimesHistogramTopPadding +
+                GymDetailPopularTimesCell.Constants.popularTimesHistogramHeight +
+                GymDetailPopularTimesCell.Constants.dividerViewTopPadding +
+                GymDetailPopularTimesCell.Constants.dividerViewHeight)
+            return CGSize(width: width, height: height)
         case.facilities:
-            let tableViewHeight = GymDetailFacilitiesCell.Constants.gymFacilitiesCellHeight * CGFloat(gymDetail.facilities.count)
-            return CGSize(width: width, height: GymDetailFacilitiesCell.baseHeight + tableViewHeight)
+            let baseHeight = CGFloat(GymDetailFacilitiesCell.Constants.facilitiesLabelTopPadding +
+                GymDetailFacilitiesCell.Constants.facilitiesLabelHeight +
+                GymDetailFacilitiesCell.Constants.gymFacilitiesTopPadding +
+                GymDetailFacilitiesCell.Constants.dividerTopPadding +
+                GymDetailFacilitiesCell.Constants.dividerHeight)
+            let tableViewHeight = GymDetailFacilitiesCell.Constants.gymFacilitiesCellHeight *
+                    CGFloat(gymDetail.facilities.count)
+            return CGSize(width: width, height: baseHeight + tableViewHeight)
         case.classes:
+            let baseHeight = CGFloat(GymDetailTodaysClassesCell.Constants.todaysClassesLabelTopPadding +
+                GymDetailTodaysClassesCell.Constants.todaysClassesLabelHeight)
             return (todaysClasses.isEmpty) ?
-                CGSize(width: width, height: GymDetailTodaysClassesCell.baseHeight +
-                    GymDetailTodaysClassesCell.Constants.noMoreClassesLabelTopPadding +
+                CGSize(width: width, height: baseHeight + GymDetailTodaysClassesCell.Constants.noMoreClassesLabelTopPadding +
                     GymDetailTodaysClassesCell.Constants.noMoreClassesLabelHeight +
                     GymDetailTodaysClassesCell.Constants.noMoreClassesLabelBottomPadding)
-                : CGSize(width: width, height: GymDetailTodaysClassesCell.baseHeight +
+                : CGSize(width: width, height: baseHeight +
                     (2.0 * GymDetailTodaysClassesCell.Constants.classesCollectionViewVerticalPadding) +
                     classesCollectionViewHeight())
         }

--- a/Uplift/Models/GymDetail.swift
+++ b/Uplift/Models/GymDetail.swift
@@ -12,10 +12,20 @@ struct GymDetail {
 
     let gym: Gym
     var hoursDataIsDropped: Bool
+    let facilities: [String]
+    
+    private let facilitiesData: [String: [String]] = [
+        GymIds.appel: ["Fitness Center"],
+        GymIds.helenNewman: ["Fitness Center", "Pool", "16 Lane Bowling Center", "Two-Court Gymnasium", "Dance Studio"],
+        GymIds.noyes: ["Fitness Center", "Game Area", "Indoor Basketball Court", "Outdoor Basketball Court", "Bouldering Wall", "Multi-Purpose Room"],
+        GymIds.teagleDown: ["Fitness Center", "Pool"],
+        GymIds.teagleUp: ["Fitness Center", "Pool"]
+    ]
 
     init(gym: Gym) {
         self.gym = gym
         self.hoursDataIsDropped = false
+        self.facilities = facilitiesData[gym.id] ?? []
     }
 
 }

--- a/Uplift/Views/GymDetail/GymDetailFacilitiesCell.swift
+++ b/Uplift/Views/GymDetail/GymDetailFacilitiesCell.swift
@@ -20,11 +20,6 @@ class GymDetailFacilitiesCell: UICollectionViewCell {
         static let facilitiesLabelTopPadding = 23
     }
 
-    // MARK: - Public data vars
-    static var baseHeight: CGFloat {
-        return CGFloat(Constants.facilitiesLabelTopPadding + Constants.facilitiesLabelHeight + Constants.gymFacilitiesTopPadding + Constants.dividerTopPadding + Constants.dividerHeight)
-    }
-
     // MARK: - Private view vars
     private let dividerView = UIView()
     private let facilitiesLabel = UILabel()

--- a/Uplift/Views/GymDetail/GymDetailFacilitiesCell.swift
+++ b/Uplift/Views/GymDetail/GymDetailFacilitiesCell.swift
@@ -29,19 +29,8 @@ class GymDetailFacilitiesCell: UICollectionViewCell {
     private let dividerView = UIView()
     private let facilitiesLabel = UILabel()
     private var gymFacilitiesTableView: UITableView!
-    static var gymFacilitiesCount: Int = 0
-
-    // MARK: - Private data vars
-    private let facilitiesData: [String: [String]] = [
-        GymIds.appel: ["Fitness Center"],
-        GymIds.helenNewman: ["Fitness Center", "Pool", "16 Lane Bowling Center", "Two-Court Gymnasium", "Dance Studio"],
-        GymIds.noyes: ["Fitness Center", "Game Area", "Indoor Basketball Court", "Outdoor Basketball Court", "Bouldering Wall", "Multi-Purpose Room"],
-        GymIds.teagleDown: ["Fitness Center", "Pool"],
-        GymIds.teagleUp: ["Fitness Center", "Pool"]
-    ]
 
     private var gymFacilities: [String] = []
-    private var gymId: String = ""
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -51,11 +40,9 @@ class GymDetailFacilitiesCell: UICollectionViewCell {
     }
 
     // MARK: - Public configure
-    func configure(for gym: Gym) {
-        gymId = gym.id
-        gymFacilities = facilitiesData[gym.id]!
-        GymDetailFacilitiesCell.gymFacilitiesCount = gymFacilities.count
-
+    func configure(for gymDetail: GymDetail) {
+        gymFacilities = gymDetail.facilities
+        
         DispatchQueue.main.async {
             self.gymFacilitiesTableView.reloadData()
             self.setupConstraints()

--- a/Uplift/Views/GymDetail/GymDetailFacilitiesCell.swift
+++ b/Uplift/Views/GymDetail/GymDetailFacilitiesCell.swift
@@ -12,8 +12,6 @@ class GymDetailFacilitiesCell: UICollectionViewCell {
 
     // MARK: - Constraint constants
     enum Constants {
-        static let dividerHeight = 1
-        static let dividerTopPadding = 24
         static let gymFacilitiesCellHeight: CGFloat = 20
         static let gymFacilitiesTopPadding = 12
         static let facilitiesLabelHeight = 22
@@ -82,9 +80,9 @@ class GymDetailFacilitiesCell: UICollectionViewCell {
             }
 
             dividerView.snp.remakeConstraints { make in
-                make.top.equalTo(gymFacilitiesTableView.snp.bottom).offset(Constants.dividerTopPadding)
+                make.top.equalTo(gymFacilitiesTableView.snp.bottom).offset(GymDetailViewController.ConstraintConstants.dividerViewTopPadding)
                 make.leading.trailing.equalToSuperview()
-                make.height.equalTo(Constants.dividerHeight)
+                make.height.equalTo(GymDetailViewController.ConstraintConstants.dividerHeight)
             }
         }
     }

--- a/Uplift/Views/GymDetail/GymDetailHoursCell.swift
+++ b/Uplift/Views/GymDetail/GymDetailHoursCell.swift
@@ -25,6 +25,11 @@ class GymDetailHoursCell: UICollectionViewCell {
         static let hoursTitleLabelTopPadding = 36
     }
 
+    // MARK: - Public data vars
+    static var baseHeight : CGFloat {
+        return CGFloat(Constants.hoursTitleLabelTopPadding + Constants.hoursTitleLabelHeight + Constants.hoursTableViewTopPadding + Constants.dividerTopPadding + Constants.dividerHeight)
+    }
+
     // MARK: - Private data vars
     private enum Days {
         case sunday

--- a/Uplift/Views/GymDetail/GymDetailHoursCell.swift
+++ b/Uplift/Views/GymDetail/GymDetailHoursCell.swift
@@ -25,11 +25,6 @@ class GymDetailHoursCell: UICollectionViewCell {
         static let hoursTitleLabelTopPadding = 36
     }
 
-    // MARK: - Public data vars
-    static var baseHeight : CGFloat {
-        return CGFloat(Constants.hoursTitleLabelTopPadding + Constants.hoursTitleLabelHeight + Constants.hoursTableViewTopPadding + Constants.dividerTopPadding + Constants.dividerHeight)
-    }
-
     // MARK: - Private data vars
     private enum Days {
         case sunday

--- a/Uplift/Views/GymDetail/GymDetailHoursCell.swift
+++ b/Uplift/Views/GymDetail/GymDetailHoursCell.swift
@@ -16,7 +16,6 @@ class GymDetailHoursCell: UICollectionViewCell {
 
     // MARK: - Constraint constants
     enum Constants {
-        static let dividerHeight = 1
         static let dividerTopPadding = 32
         static let hoursTableViewDroppedHeight = 181
         static let hoursTableViewHeight = 19
@@ -131,7 +130,7 @@ class GymDetailHoursCell: UICollectionViewCell {
         dividerView.snp.updateConstraints {make in
             make.top.equalTo(hoursTableView.snp.bottom).offset(Constants.dividerTopPadding)
             make.leading.trailing.equalToSuperview()
-            make.height.equalTo(Constants.dividerHeight)
+            make.height.equalTo(GymDetailViewController.ConstraintConstants.dividerHeight)
         }
     }
 

--- a/Uplift/Views/GymDetail/GymDetailPopularTimesCell.swift
+++ b/Uplift/Views/GymDetail/GymDetailPopularTimesCell.swift
@@ -20,14 +20,6 @@ class GymDetailPopularTimesCell: UICollectionViewCell {
         static let popularTimesLabelTopPadding = 24
     }
 
-    // MARK: - Public data vars
-    static var baseHeight: CGFloat {
-        let labelHeight = Constants.popularTimesLabelTopPadding + Constants.popularTimesLabelHeight
-        let histogramHeight = Constants.popularTimesHistogramTopPadding + Constants.popularTimesHistogramHeight
-        let dividerHeight = Constants.dividerViewTopPadding + Constants.dividerViewHeight
-        return CGFloat(labelHeight + histogramHeight + dividerHeight)
-    }
-
     // MARK: - Private view vars
     private var popularTimesHistogram: Histogram!
     private let popularTimesLabel = UILabel()

--- a/Uplift/Views/GymDetail/GymDetailPopularTimesCell.swift
+++ b/Uplift/Views/GymDetail/GymDetailPopularTimesCell.swift
@@ -12,10 +12,7 @@ class GymDetailPopularTimesCell: UICollectionViewCell {
 
     // MARK: - Constraint constants
     enum Constants {
-        static let dividerViewHeight = 1
-        static let dividerViewTopPadding = 24
         static let popularTimesHistogramHeight = 101
-        static let popularTimesHistogramTopPadding = 24
         static let popularTimesLabelHeight = 19
         static let popularTimesLabelTopPadding = 24
     }
@@ -85,14 +82,14 @@ class GymDetailPopularTimesCell: UICollectionViewCell {
             }
 
             dividerView.snp.remakeConstraints { make in
-                make.top.equalTo(histogram.snp.bottom).offset(Constants.dividerViewTopPadding)
-                make.height.equalTo(Constants.dividerViewHeight)
+                make.top.equalTo(histogram.snp.bottom).offset(GymDetailViewController.ConstraintConstants.dividerViewTopPadding)
+                make.height.equalTo(GymDetailViewController.ConstraintConstants.dividerHeight)
                 make.leading.trailing.equalToSuperview()
             }
         } else {
             dividerView.snp.makeConstraints { make in
-                make.top.equalTo(popularTimesLabel.snp.bottom).offset(Constants.dividerViewTopPadding)
-                make.height.equalTo(Constants.dividerViewHeight)
+                make.top.equalTo(popularTimesLabel.snp.bottom).offset(GymDetailViewController.ConstraintConstants.dividerViewTopPadding)
+                make.height.equalTo(GymDetailViewController.ConstraintConstants.dividerHeight)
                 make.leading.trailing.equalToSuperview()
             }
         }

--- a/Uplift/Views/GymDetail/GymDetailTodaysClassesCell.swift
+++ b/Uplift/Views/GymDetail/GymDetailTodaysClassesCell.swift
@@ -17,11 +17,10 @@ class GymDetailTodaysClassesCell: UICollectionViewCell {
     // MARK: - Constraint constants
     enum Constants {
         static let classesCollectionViewVerticalPadding: CGFloat = 32
-        static let noMoreClassesLabelBottomPadding: CGFloat = 57
         static let noMoreClassesLabelHeight: CGFloat = 66
         static let noMoreClassesLabelTopPadding: CGFloat = 22
         static let todaysClassesLabelHeight: CGFloat = 18
-        static let todaysClassesLabelTopPadding: CGFloat = 64
+        static let todaysClassesLabelTopPadding: CGFloat = 62
     }
 
     // MARK: - Private view vars

--- a/Uplift/Views/GymDetail/GymDetailTodaysClassesCell.swift
+++ b/Uplift/Views/GymDetail/GymDetailTodaysClassesCell.swift
@@ -20,7 +20,7 @@ class GymDetailTodaysClassesCell: UICollectionViewCell {
         static let noMoreClassesLabelHeight: CGFloat = 66
         static let noMoreClassesLabelTopPadding: CGFloat = 22
         static let todaysClassesLabelHeight: CGFloat = 18
-        static let todaysClassesLabelTopPadding: CGFloat = 62
+        static let todaysClassesLabelTopPadding: CGFloat = 24
     }
 
     // MARK: - Private view vars
@@ -53,8 +53,8 @@ class GymDetailTodaysClassesCell: UICollectionViewCell {
 
     // MARK: - Private helpers
     private func setupViews() {
-        todaysClassesLabel.font = ._14MontserratSemiBold
-        todaysClassesLabel.textColor = .fitnessDarkGrey
+        todaysClassesLabel.font = ._16MontserratMedium
+        todaysClassesLabel.textColor = .fitnessBlack
         todaysClassesLabel.text = "TODAY'S CLASSES"
         todaysClassesLabel.textAlignment = .center
         contentView.addSubview(todaysClassesLabel)

--- a/Uplift/Views/GymDetail/GymDetailTodaysClassesCell.swift
+++ b/Uplift/Views/GymDetail/GymDetailTodaysClassesCell.swift
@@ -24,11 +24,6 @@ class GymDetailTodaysClassesCell: UICollectionViewCell {
         static let todaysClassesLabelTopPadding: CGFloat = 64
     }
 
-    // MARK: - Public data vars
-    static var baseHeight: CGFloat {
-        return Constants.todaysClassesLabelTopPadding + Constants.todaysClassesLabelHeight
-    }
-
     // MARK: - Private view vars
     private var classesCollectionView: UICollectionView!
     private let noMoreClassesLabel = UILabel()


### PR DESCRIPTION
This PR fixes the bug where if you go into a GymDetailViewController -> to home screen -> Go into another gym's GymDetailViewController again, the height for the facilities section would be incorrect.

The reason for this is similar to the bug in the hours data. We were using static vars to determine the number of facilities for a gym. This PR fixes it by making `facilities` it a property of the new `GymDetail` model.

Also addressed #170 and moved cell height calculation to the GymDetailVC and refactored constraints not used in the cells to the VC.

NOTE: Demo video in #uplift-ios