### PR TITLE
Standardize spacing in cells

### DIFF
--- a/Uplift/Controllers/ClassDetailViewController.swift
+++ b/Uplift/Controllers/ClassDetailViewController.swift
@@ -237,32 +237,67 @@ extension ClassDetailViewController: UICollectionViewDataSource, UICollectionVie
     }
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        let descriptionTextViewHorizontalPadding = 40
-        let descriptionLabelHorizontalPadding = 48
-        let nextSessionsCellHeight = 112
         let width = collectionView.frame.width
         let itemType = sections[indexPath.section].items[indexPath.item]
-        
+
         switch itemType {
         case .time:
-            return CGSize(width: width, height: ClassDetailTimeCell.height)
+            return CGSize(width: width, height: getTimeHeight())
         case .function:
-            let descriptionLabelWidth = width - CGFloat(descriptionLabelHorizontalPadding * 2)
-            let string = gymClassInstance.tags.map { $0.name }.joined(separator: " · ")
-            let descriptionLabelHeight = string.height(withConstrainedWidth: descriptionLabelWidth, font: UIFont._14MontserratLight!)
-            return CGSize(width: width, height: ClassDetailFunctionCell.baseHeight + descriptionLabelHeight)
+            return CGSize(width: width, height: getFunctionHeight(width: width))
         case .description:
-            let descriptionTextViewWidth = width - CGFloat(descriptionTextViewHorizontalPadding * 2)
-            let descriptionTextViewHeight = gymClassInstance.classDescription.height(withConstrainedWidth: descriptionTextViewWidth, font: UIFont._14MontserratLight!)
-            let height = ClassDetailDescriptionCell.baseHeight + descriptionTextViewHeight
-            return CGSize(width: width, height: height)
+            return CGSize(width: width, height: getDescriptionHeight(width: width))
         case .nextSessions(let nextSessions):
-            let nextSesssionsCollectionViewHeight = nextSessions.count * nextSessionsCellHeight
-            let height = ClassDetailNextSessionsCell.baseHeight + CGFloat(nextSesssionsCollectionViewHeight)
-            return CGSize(width: width, height: height)
+            return CGSize(width: width, height: getNextSessionsHeight(numberOfSessions: CGFloat(nextSessions.count)))
         }
     }
 
+}
+
+// MARK: - Item Height Calculations
+extension ClassDetailViewController {
+    func getTimeHeight() -> CGFloat {
+        return Constraints.verticalPadding + Constraints.titleLabelHeight +
+            ClassDetailTimeCell.Constants.timeLabelTopPadding + Constraints.titleLabelHeight +
+            ClassDetailTimeCell.Constants.addToCalendarButtonTopPadding +
+            ClassDetailTimeCell.Constants.addToCalendarButtonHeight +
+            ClassDetailTimeCell.Constants.addToCalendarLabelTopPadding +
+            ClassDetailTimeCell.Constants.addToCalendarLabelHeight +
+            Constraints.verticalPadding + Constraints.dividerViewHeight
+    }
+
+    func getFunctionHeight(width: CGFloat) -> CGFloat {
+        let baseHeight = Constraints.verticalPadding + Constraints.titleLabelHeight +
+            ClassDetailFunctionCell.Constants.functionDescriptionLabelTopPadding +
+            Constraints.verticalPadding + Constraints.dividerViewHeight
+
+        let descriptionLabelWidth = width - CGFloat(ClassDetailFunctionCell.Constants.descriptionLabelHorizontalPadding * 2)
+        let string = gymClassInstance.tags.map { $0.name }.joined(separator: " · ")
+        let descriptionLabelHeight = string.height(withConstrainedWidth: descriptionLabelWidth, font: UIFont._14MontserratLight!)
+
+        return baseHeight + descriptionLabelHeight
+    }
+
+    func getDescriptionHeight(width: CGFloat) -> CGFloat {
+        let baseHeight = 2.0 * Constraints.verticalPadding + Constraints.dividerViewHeight
+
+        let descriptionTextViewWidth = width - CGFloat(ClassDetailDescriptionCell.Constants.descriptionTextViewHorizontalPadding * 2)
+        let descriptionTextViewHeight = gymClassInstance.classDescription.height(withConstrainedWidth: descriptionTextViewWidth, font: UIFont._14MontserratLight!)
+
+        return baseHeight + descriptionTextViewHeight
+    }
+
+    func getNextSessionsHeight(numberOfSessions: CGFloat) -> CGFloat {
+        let nextSessionsCellHeight: CGFloat = 112
+
+        let baseHeight = Constraints.verticalPadding + Constraints.titleLabelHeight +
+            ClassDetailNextSessionsCell.Constants.collectionViewTopPadding +
+            ClassDetailNextSessionsCell.Constants.collectionViewBottomPadding
+
+        let nextSessionsCollectionViewHeight = numberOfSessions * nextSessionsCellHeight
+
+        return baseHeight + nextSessionsCollectionViewHeight
+    }
 }
 
 // MARK: - Layout

--- a/Uplift/Controllers/ClassListViewController.swift
+++ b/Uplift/Controllers/ClassListViewController.swift
@@ -390,9 +390,11 @@ extension ClassListViewController {
 
         titleView = UIView()
         titleView.backgroundColor = .white
-        titleView.layer.shadowOffset = CGSize(width: 0, height: 9)
+        titleView.layer.shadowOffset = CGSize(width: 0.0, height: 4.0)
+        titleView.layer.shadowOpacity = 0.4
+        titleView.layer.shadowRadius = 10.0
         titleView.layer.shadowColor = UIColor.buttonShadow.cgColor
-        titleView.layer.shadowOpacity = 0.25
+        titleView.layer.masksToBounds = false
         titleView.clipsToBounds = false
         view.addSubview(titleView)
 
@@ -447,7 +449,8 @@ extension ClassListViewController {
         }
 
         calendarCollectionView.snp.makeConstraints { make in
-            make.top.equalTo(titleView.snp.bottom).offset(calendarCollectionViewTopPadding)
+            make.top.equalTo(titleView.snp.bottom)
+                .offset(calendarCollectionViewTopPadding)
             make.height.equalTo(calendarCollectionViewHeight)
             make.leading.trailing.equalToSuperview()
         }
@@ -478,6 +481,7 @@ extension ClassListViewController {
         calendarCollectionView.showsHorizontalScrollIndicator = false
         calendarCollectionView.backgroundColor = .white
         calendarCollectionView.register(CalendarCell.self, forCellWithReuseIdentifier: Constants.calendarCellIdentifier)
+        calendarCollectionView.layer.zPosition = -1
         view.addSubview(calendarCollectionView)
 
         classCollectionView.delegate = self

--- a/Uplift/Controllers/FavoritesViewController.swift
+++ b/Uplift/Controllers/FavoritesViewController.swift
@@ -20,9 +20,11 @@ class FavoritesViewController: UIViewController {
         didSet {
             if favoritesNames.isEmpty {
                 classesCollectionView.removeFromSuperview()
+                emptyStateView.layer.zPosition = -1
                 view.addSubview(emptyStateView)
             } else {
                 emptyStateView.removeFromSuperview()
+                classesCollectionView.layer.zPosition = -1
                 view.addSubview(classesCollectionView)
                 classesCollectionView.reloadData()
             }
@@ -42,9 +44,11 @@ class FavoritesViewController: UIViewController {
         // TITLE
         titleBackground = UIView()
         titleBackground.backgroundColor = .white
-        titleBackground.layer.shadowOffset = CGSize(width: 0, height: 9)
+        titleBackground.layer.shadowOffset = CGSize(width: 0.0, height: 4.0)
+        titleBackground.layer.shadowOpacity = 0.4
+        titleBackground.layer.shadowRadius = 10.0
         titleBackground.layer.shadowColor = UIColor.buttonShadow.cgColor
-        titleBackground.layer.shadowOpacity = 0.25
+        titleBackground.layer.masksToBounds = false
         titleBackground.clipsToBounds = false
         view.addSubview(titleBackground)
 
@@ -57,6 +61,7 @@ class FavoritesViewController: UIViewController {
         // EMPTY STATE
         emptyStateView = NoFavoritesEmptyStateView(frame: .zero)
         emptyStateView.delegate = self
+        emptyStateView.layer.zPosition = -1
         view.addSubview(emptyStateView)
 
         // COLLECTION VIEW
@@ -75,6 +80,7 @@ class FavoritesViewController: UIViewController {
 
         classesCollectionView.register(FavoritesHeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: FavoritesHeaderView.identifier)
         classesCollectionView.register(ClassListCell.self, forCellWithReuseIdentifier: ClassListCell.identifier)
+        classesCollectionView.layer.zPosition = -1
         view.addSubview(classesCollectionView)
 
         setupConstraints()
@@ -108,7 +114,7 @@ class FavoritesViewController: UIViewController {
         let titleLeading = 24
         let titleBottom = -20
         let titleHeight = 26
-        
+
         titleBackground.snp.makeConstraints { make in
             make.leading.trailing.top.equalToSuperview()
             make.height.equalTo(titleBackgroundHeight)
@@ -151,7 +157,7 @@ extension FavoritesViewController: ClassListCellDelegate, NavigationDelegate {
         classListViewController.updateCalendarDateSelectedToToday()
 
         classNavigationController.setViewControllers([classListViewController], animated: false)
-        
+
         tabBarController?.selectedIndex = 1
     }
 }

--- a/Uplift/Controllers/GymDetailViewController+Extensions.swift
+++ b/Uplift/Controllers/GymDetailViewController+Extensions.swift
@@ -15,7 +15,7 @@ extension GymDetailViewController: GymDetailHoursCellDelegate {
         collectionView.performBatchUpdates({}, completion: nil)
         completion()
     }
-    
+
 }
 
 extension GymDetailViewController: GymDetailTodaysClassesCellDelegate {

--- a/Uplift/Controllers/GymDetailViewController.swift
+++ b/Uplift/Controllers/GymDetailViewController.swift
@@ -227,19 +227,12 @@ extension GymDetailViewController {
 
 // MARK: - Item Height Calculations
 extension GymDetailViewController {
-    enum ConstraintConstants {
-        static let dividerHeight: CGFloat = 1
-        static let noMoreClassesLabelBottomPadding: CGFloat = 34
-        static let titleLabelHeight: CGFloat = 18
-        static let verticalPadding: CGFloat = 34
-    }
-
-    func getHoursHeight() -> CGFloat {
-        let baseHeight = ConstraintConstants.verticalPadding +
-            ConstraintConstants.titleLabelHeight +
+func getHoursHeight() -> CGFloat {
+        let baseHeight = Constraints.verticalPadding +
+            Constraints.titleLabelHeight +
             GymDetailHoursCell.Constants.hoursTableViewTopPadding +
-            ConstraintConstants.verticalPadding +
-            ConstraintConstants.dividerHeight
+            Constraints.verticalPadding +
+            Constraints.dividerViewHeight
 
         let height = gymDetail.hoursDataIsDropped
             ? baseHeight + GymDetailHoursCell.Constants.hoursTableViewDroppedHeight
@@ -248,25 +241,25 @@ extension GymDetailViewController {
     }
 
     func getBusyTimesHeight() -> CGFloat {
-        let labelHeight = ConstraintConstants.verticalPadding +
-            ConstraintConstants.titleLabelHeight
+        let labelHeight = Constraints.verticalPadding +
+            Constraints.titleLabelHeight
 
         let histogramHeight =
         GymDetailPopularTimesCell.Constants.popularTimesHistogramTopPadding +
         GymDetailPopularTimesCell.Constants.popularTimesHistogramHeight
 
-        let dividerHeight = ConstraintConstants.verticalPadding +
-        ConstraintConstants.dividerHeight
+        let dividerHeight = Constraints.verticalPadding +
+        Constraints.dividerViewHeight
 
         return labelHeight + histogramHeight + dividerHeight
     }
 
     func getFacilitiesHeight() -> CGFloat {
-        let baseHeight = ConstraintConstants.verticalPadding +
-            ConstraintConstants.titleLabelHeight +
+        let baseHeight = Constraints.verticalPadding +
+            Constraints.titleLabelHeight +
             GymDetailFacilitiesCell.Constants.gymFacilitiesTopPadding +
-            ConstraintConstants.verticalPadding +
-            ConstraintConstants.dividerHeight
+            Constraints.verticalPadding +
+            Constraints.dividerViewHeight
 
         let tableViewHeight = GymDetailFacilitiesCell.Constants.gymFacilitiesCellHeight *
                 CGFloat(gymDetail.facilities.count)
@@ -275,12 +268,12 @@ extension GymDetailViewController {
     }
 
     func getTodaysClassesHeight() -> CGFloat {
-        let baseHeight = ConstraintConstants.verticalPadding +
-            ConstraintConstants.titleLabelHeight
+        let baseHeight = Constraints.verticalPadding +
+            Constraints.titleLabelHeight
 
         let noMoreClassesHeight = GymDetailTodaysClassesCell.Constants.noMoreClassesLabelTopPadding +
             GymDetailTodaysClassesCell.Constants.noMoreClassesLabelHeight +
-            ConstraintConstants.verticalPadding
+            Constraints.verticalPadding
 
         let collectionViewHeight = 2.0 * GymDetailTodaysClassesCell.Constants.classesCollectionViewVerticalPadding +
             classesCollectionViewHeight()

--- a/Uplift/Controllers/GymDetailViewController.swift
+++ b/Uplift/Controllers/GymDetailViewController.swift
@@ -174,6 +174,10 @@ extension GymDetailViewController: UICollectionViewDataSource, UICollectionViewD
         return CGSize(width: collectionView.frame.width, height: 360)
     }
 
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        return 0
+    }
+
     private func classesCollectionViewHeight() -> CGFloat {
         let cellPadding: CGFloat = 12
         let cellHeight: CGFloat = 100
@@ -224,54 +228,60 @@ extension GymDetailViewController {
 // MARK: - Item Height Calculations
 extension GymDetailViewController {
     enum ConstraintConstants {
-        static let dividerHeight = 1
-        static let dividerViewTopPadding = 24
-        static let popularTimesHistogramTopPadding = 24
-        static let noMoreClassesLabelBottomPadding: CGFloat = 57
+        static let dividerHeight: CGFloat = 1
+        static let noMoreClassesLabelBottomPadding: CGFloat = 34
+        static let titleLabelHeight: CGFloat = 18
+        static let verticalPadding: CGFloat = 34
     }
 
     func getHoursHeight() -> CGFloat {
-        let baseHeight = CGFloat(GymDetailHoursCell.Constants.hoursTitleLabelTopPadding +
-            GymDetailHoursCell.Constants.hoursTitleLabelHeight +
+        let baseHeight = ConstraintConstants.verticalPadding +
+            ConstraintConstants.titleLabelHeight +
             GymDetailHoursCell.Constants.hoursTableViewTopPadding +
-            GymDetailHoursCell.Constants.dividerTopPadding +
-            ConstraintConstants.dividerHeight)
+            ConstraintConstants.verticalPadding +
+            ConstraintConstants.dividerHeight
+
         let height = gymDetail.hoursDataIsDropped
-            ? baseHeight + CGFloat(GymDetailHoursCell.Constants.hoursTableViewDroppedHeight)
-            : baseHeight + CGFloat(GymDetailHoursCell.Constants.hoursTableViewHeight)
+            ? baseHeight + GymDetailHoursCell.Constants.hoursTableViewDroppedHeight
+            : baseHeight + GymDetailHoursCell.Constants.hoursTableViewHeight
         return height
     }
 
     func getBusyTimesHeight() -> CGFloat {
-        let labelHeight = GymDetailPopularTimesCell.Constants.popularTimesLabelTopPadding +
-        GymDetailPopularTimesCell.Constants.popularTimesLabelHeight
+        let labelHeight = ConstraintConstants.verticalPadding +
+            ConstraintConstants.titleLabelHeight
 
-        let histogramHeight = ConstraintConstants.popularTimesHistogramTopPadding +
+        let histogramHeight =
+        GymDetailPopularTimesCell.Constants.popularTimesHistogramTopPadding +
         GymDetailPopularTimesCell.Constants.popularTimesHistogramHeight
 
-        let dividerHeight = ConstraintConstants.dividerViewTopPadding +
+        let dividerHeight = ConstraintConstants.verticalPadding +
         ConstraintConstants.dividerHeight
 
-        return CGFloat(labelHeight + histogramHeight + dividerHeight)
+        return labelHeight + histogramHeight + dividerHeight
     }
 
     func getFacilitiesHeight() -> CGFloat {
-        let baseHeight = CGFloat(GymDetailFacilitiesCell.Constants.facilitiesLabelTopPadding +
-            GymDetailFacilitiesCell.Constants.facilitiesLabelHeight +
+        let baseHeight = ConstraintConstants.verticalPadding +
+            ConstraintConstants.titleLabelHeight +
             GymDetailFacilitiesCell.Constants.gymFacilitiesTopPadding +
-            ConstraintConstants.dividerViewTopPadding +
-            ConstraintConstants.dividerHeight)
+            ConstraintConstants.verticalPadding +
+            ConstraintConstants.dividerHeight
+
         let tableViewHeight = GymDetailFacilitiesCell.Constants.gymFacilitiesCellHeight *
                 CGFloat(gymDetail.facilities.count)
+
         return baseHeight + tableViewHeight
     }
 
     func getTodaysClassesHeight() -> CGFloat {
-        let baseHeight = CGFloat(GymDetailTodaysClassesCell.Constants.todaysClassesLabelTopPadding +
-            GymDetailTodaysClassesCell.Constants.todaysClassesLabelHeight)
+        let baseHeight = ConstraintConstants.verticalPadding +
+            ConstraintConstants.titleLabelHeight
+
         let noMoreClassesHeight = GymDetailTodaysClassesCell.Constants.noMoreClassesLabelTopPadding +
             GymDetailTodaysClassesCell.Constants.noMoreClassesLabelHeight +
-            ConstraintConstants.noMoreClassesLabelBottomPadding
+            ConstraintConstants.verticalPadding
+
         let collectionViewHeight = 2.0 * GymDetailTodaysClassesCell.Constants.classesCollectionViewVerticalPadding +
             classesCollectionViewHeight()
 

--- a/Uplift/Controllers/HomeViewController.swift
+++ b/Uplift/Controllers/HomeViewController.swift
@@ -79,7 +79,7 @@ class HomeViewController: UIViewController {
             // Reload Today's Classes section
             self.collectionView.reloadSections(IndexSet(integer: 1))
         }
-        
+
         NetworkManager.shared.getTags { tags in
             self.lookingForCategories = tags
             self.collectionView.reloadSections(IndexSet(integer: 2))
@@ -104,8 +104,9 @@ class HomeViewController: UIViewController {
 extension HomeViewController {
 
     private func setupViews() {
-        headerView.layer.shadowOffset = CGSize(width: 0.0, height: 9.0)
-        headerView.layer.shadowOpacity = 0.25
+        headerView.layer.shadowOffset = CGSize(width: 0.0, height: 4.0)
+        headerView.layer.shadowOpacity = 0.4
+        headerView.layer.shadowRadius = 10.0
         headerView.layer.shadowColor = UIColor.buttonShadow.cgColor
         headerView.layer.masksToBounds = false
 
@@ -122,6 +123,7 @@ extension HomeViewController {
         collectionView.backgroundColor = .white
         collectionView.delaysContentTouches = false
         collectionView.showsVerticalScrollIndicator = false
+        collectionView.layer.zPosition = -1
         collectionView.register(HomeSectionHeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: HomeSectionHeaderView.identifier)
         collectionView.register(CheckInsListCell.self, forCellWithReuseIdentifier: Constants.checkInsListCellIdentifier)
         collectionView.register(GymsListCell.self, forCellWithReuseIdentifier: Constants.gymsListCellIdentifier)
@@ -131,7 +133,6 @@ extension HomeViewController {
     }
 
     private func setupConstraints() {
-        let collectionViewTopPadding = 12
         let headerViewHeight = 120
 
         headerView.snp.makeConstraints { make in
@@ -141,7 +142,7 @@ extension HomeViewController {
 
         collectionView.snp.makeConstraints { make in
             make.centerX.width.bottom.equalToSuperview()
-            make.top.equalTo(headerView.snp.bottom).offset(collectionViewTopPadding)
+            make.top.equalTo(headerView.snp.bottom)
         }
     }
 

--- a/Uplift/Supporting/Constants.swift
+++ b/Uplift/Supporting/Constants.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2018 Uplift. All rights reserved.
 //
 
-import Foundation
 import UIKit
 
 // MARK: - CONSTRAINTS

--- a/Uplift/Supporting/Constants.swift
+++ b/Uplift/Supporting/Constants.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  Constants.swift
 //  Uplift
 //
 //  Created by Joseph Fulgieri on 8/31/18.
@@ -7,6 +7,14 @@
 //
 
 import Foundation
+import UIKit
+
+// MARK: - CONSTRAINTS
+struct Constraints {
+    static let dividerViewHeight: CGFloat = 1
+    static let titleLabelHeight: CGFloat = 18
+    static let verticalPadding: CGFloat = 34
+}
 
 // MARK: - DAY ABBREVIATIONS
 struct DayAbbreviations {

--- a/Uplift/Views/ClassDetail/ClassDetailDescriptionCell.swift
+++ b/Uplift/Views/ClassDetail/ClassDetailDescriptionCell.swift
@@ -12,17 +12,17 @@ class ClassDetailDescriptionCell: UICollectionViewCell {
 
     // MARK: - Constraint constants
     enum Constants {
-        static let descriptionTextViewBottomPadding: CGFloat = 64
-        static let descriptionTextViewTopPadding: CGFloat = 24
+        static let descriptionTextViewHorizontalPadding: CGFloat = 40
     }
 
     // MARK: - Public data vars
     static var baseHeight: CGFloat {
-        return Constants.descriptionTextViewTopPadding + Constants.descriptionTextViewBottomPadding
+        return 2.0 * Constraints.verticalPadding + Constraints.dividerViewHeight
     }
 
     // MARK: - Private view vars
     private let descriptionTextView = UITextView()
+    private let dividerView = UIView()
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -47,17 +47,24 @@ class ClassDetailDescriptionCell: UICollectionViewCell {
         descriptionTextView.textContainerInset = UIEdgeInsets.zero
         descriptionTextView.textContainer.lineFragmentPadding = 0
         contentView.addSubview(descriptionTextView)
+        descriptionTextView.sizeToFit()
+
+        dividerView.backgroundColor = .fitnessMutedGreen
+        contentView.addSubview(dividerView)
     }
 
     private func setupConstraints() {
-        let descriptionTextViewHorizontalPadding = 40
-        let descriptionTextViewVerticalPadding = 24
-
         descriptionTextView.snp.makeConstraints { make in
-            make.leading.equalToSuperview().offset(descriptionTextViewHorizontalPadding)
-            make.trailing.equalToSuperview().offset(-descriptionTextViewHorizontalPadding)
-            make.top.equalToSuperview().offset(descriptionTextViewVerticalPadding)
-            make.bottom.equalToSuperview().offset(-descriptionTextViewVerticalPadding)
+            make.leading.equalToSuperview().offset(Constants.descriptionTextViewHorizontalPadding)
+            make.trailing.equalToSuperview().inset(Constants.descriptionTextViewHorizontalPadding)
+            make.top.equalToSuperview().offset(Constraints.verticalPadding)
+            make.bottom.equalToSuperview().inset(Constraints.verticalPadding)
+        }
+
+        dividerView.snp.updateConstraints {make in
+            make.top.equalTo(descriptionTextView.snp.bottom).offset(Constraints.verticalPadding)
+            make.leading.trailing.equalToSuperview()
+            make.height.equalTo(Constraints.dividerViewHeight)
         }
     }
 

--- a/Uplift/Views/ClassDetail/ClassDetailFunctionCell.swift
+++ b/Uplift/Views/ClassDetail/ClassDetailFunctionCell.swift
@@ -12,16 +12,14 @@ class ClassDetailFunctionCell: UICollectionViewCell {
 
     // MARK: - Constraint constants
     enum Constants {
-        static let dividerSpacing: CGFloat = 24
-        static let dividerViewHeight: CGFloat = 1
+        static let descriptionLabelHorizontalPadding = 48
         static let functionDescriptionLabelTopPadding: CGFloat = 12
-        static let functionLabelHeight: CGFloat = 19
-        static let functionLabelTopPadding: CGFloat = 24
+        static let functionLabelHeight: CGFloat = 18
     }
 
     // MARK: - Public data vars
     static var baseHeight: CGFloat {
-        return Constants.functionLabelTopPadding + Constants.functionLabelHeight + Constants.functionDescriptionLabelTopPadding + Constants.dividerSpacing + Constants.dividerViewHeight
+        return Constraints.verticalPadding + Constants.functionLabelHeight + Constants.functionDescriptionLabelTopPadding + Constraints.verticalPadding + Constraints.dividerViewHeight
     }
 
     // MARK: - Private view vars
@@ -44,7 +42,7 @@ class ClassDetailFunctionCell: UICollectionViewCell {
     // MARK: - Private helpers
     private func setupViews() {
         functionLabel.text = "FUNCTION"
-        functionLabel.font = ._16MontserratMedium
+        functionLabel.font = ._16MontserratBold
         functionLabel.textAlignment = .center
         functionLabel.textColor = .fitnessLightBlack
         contentView.addSubview(functionLabel)
@@ -60,23 +58,21 @@ class ClassDetailFunctionCell: UICollectionViewCell {
     }
 
     private func setupConstraints() {
-        let descriptionLabelHorizontalPadding = 48
-    
         functionLabel.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview()
-            make.top.equalToSuperview().offset(Constants.functionLabelTopPadding)
+            make.top.equalToSuperview().offset(Constraints.verticalPadding)
             make.height.equalTo(Constants.functionLabelHeight)
         }
 
         descriptionLabel.snp.makeConstraints { make in
-            make.leading.trailing.equalToSuperview().inset(descriptionLabelHorizontalPadding)
+            make.leading.trailing.equalToSuperview().inset(Constants.descriptionLabelHorizontalPadding)
             make.top.equalTo(functionLabel.snp.bottom).offset(Constants.functionDescriptionLabelTopPadding)
         }
 
         dividerView.snp.makeConstraints { make in
-            make.height.equalTo(Constants.dividerViewHeight)
+            make.height.equalTo(Constraints.dividerViewHeight)
             make.leading.trailing.equalToSuperview()
-            make.top.equalTo(descriptionLabel.snp.bottom).offset(Constants.dividerSpacing)
+            make.top.equalTo(descriptionLabel.snp.bottom).offset(Constraints.verticalPadding)
         }
     }
 

--- a/Uplift/Views/ClassDetail/ClassDetailNextSessionsCell.swift
+++ b/Uplift/Views/ClassDetail/ClassDetailNextSessionsCell.swift
@@ -19,12 +19,11 @@ class ClassDetailNextSessionsCell: UICollectionViewCell {
     enum Constants {
         static let collectionViewBottomPadding: CGFloat = 12
         static let collectionViewTopPadding: CGFloat = 32
-        static let nextSessionsLabelHeight: CGFloat = 15
     }
 
     // MARK: - Public data vars
     static var baseHeight: CGFloat {
-        return Constants.nextSessionsLabelHeight + Constants.collectionViewTopPadding + Constants.collectionViewBottomPadding
+        return Constraints.verticalPadding + Constraints.titleLabelHeight + Constants.collectionViewTopPadding + Constants.collectionViewBottomPadding
     }
 
     // MARK: - Private view vars
@@ -55,8 +54,8 @@ class ClassDetailNextSessionsCell: UICollectionViewCell {
 
     // MARK: - Private helpers
     private func setupViews() {
-        nextSessionsLabel.font = ._12LatoBlack
-        nextSessionsLabel.textColor = .fitnessDarkGrey
+        nextSessionsLabel.font = ._16MontserratBold
+        nextSessionsLabel.textColor = .fitnessLightBlack
         nextSessionsLabel.text = "NEXT SESSIONS"
         nextSessionsLabel.textAlignment = .center
         nextSessionsLabel.sizeToFit()
@@ -83,8 +82,9 @@ class ClassDetailNextSessionsCell: UICollectionViewCell {
 
     private func setupConstraints() {
         nextSessionsLabel.snp.makeConstraints { make in
-            make.centerX.top.equalToSuperview()
-            make.height.equalTo(Constants.nextSessionsLabelHeight)
+            make.centerX.equalToSuperview()
+            make.top.equalToSuperview().offset(Constraints.verticalPadding)
+            make.height.equalTo(Constraints.titleLabelHeight)
         }
 
         collectionView.snp.makeConstraints { make in
@@ -108,6 +108,7 @@ extension ClassDetailNextSessionsCell: UICollectionViewDataSource, UICollectionV
     }
 
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        //swiftlint:disable:next force_cast
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: ClassListCell.identifier, for: indexPath) as! ClassListCell
         cell.configure(gymClassInstance: nextSessions[indexPath.item], style: .date)
         cell.delegate = self

--- a/Uplift/Views/ClassDetail/ClassDetailTimeCell.swift
+++ b/Uplift/Views/ClassDetail/ClassDetailTimeCell.swift
@@ -20,17 +20,7 @@ class ClassDetailTimeCell: UICollectionViewCell {
         static let addToCalendarButtonTopPadding: CGFloat = 26
         static let addToCalendarLabelHeight: CGFloat = 10
         static let addToCalendarLabelTopPadding: CGFloat = 5
-        static let dateLabelHeight: CGFloat = 19
-        static let dateLabelTopPadding: CGFloat = 36
-        static let dividerViewTopPadding: CGFloat = 32
-        static let dividerViewHeight: CGFloat = 1
-        static let timeLabelHeight: CGFloat = 19
         static let timeLabelTopPadding: CGFloat = 8
-    }
-
-    // MARK: - Public data vars
-    static var height: CGFloat {
-        return Constants.dateLabelTopPadding + Constants.dateLabelHeight + Constants.timeLabelTopPadding + Constants.timeLabelHeight + Constants.addToCalendarButtonTopPadding + Constants.addToCalendarButtonHeight + Constants.addToCalendarLabelTopPadding + Constants.addToCalendarLabelHeight + Constants.dividerViewTopPadding + Constants.dividerViewHeight
     }
 
     // MARK: - Private view vars
@@ -106,16 +96,16 @@ class ClassDetailTimeCell: UICollectionViewCell {
 
         dateLabel.snp.makeConstraints { make in
             make.leading.equalToSuperview()
-            make.top.equalToSuperview().offset(Constants.dateLabelTopPadding)
+            make.top.equalToSuperview().offset(Constraints.verticalPadding)
             make.trailing.equalToSuperview()
-            make.height.equalTo(Constants.dateLabelHeight)
+            make.height.equalTo(Constraints.titleLabelHeight)
         }
 
         timeLabel.snp.makeConstraints { make in
             make.leading.equalToSuperview()
             make.top.equalTo(dateLabel.snp.bottom).offset(Constants.timeLabelTopPadding)
             make.trailing.equalToSuperview()
-            make.height.equalTo(Constants.timeLabelHeight)
+            make.height.equalTo(Constraints.titleLabelHeight)
         }
 
         addToCalendarButton.snp.makeConstraints { make in
@@ -132,10 +122,10 @@ class ClassDetailTimeCell: UICollectionViewCell {
         }
 
         dividerView.snp.makeConstraints { make in
-            make.height.equalTo(Constants.dividerViewHeight)
+            make.height.equalTo(Constraints.dividerViewHeight)
             make.leading.equalToSuperview()
             make.trailing.equalToSuperview()
-            make.top.equalTo(addToCalendarLabel.snp.bottom).offset(Constants.dividerViewTopPadding)
+            make.top.equalTo(addToCalendarLabel.snp.bottom).offset(Constraints.verticalPadding)
         }
     }
 

--- a/Uplift/Views/GymDetail/GymDetailFacilitiesCell.swift
+++ b/Uplift/Views/GymDetail/GymDetailFacilitiesCell.swift
@@ -65,9 +65,9 @@ class GymDetailFacilitiesCell: UICollectionViewCell {
 
     func setupConstraints() {
         facilitiesLabel.snp.makeConstraints { make in
-            make.top.equalToSuperview().inset(GymDetailViewController.ConstraintConstants.verticalPadding)
+            make.top.equalToSuperview().inset(Constraints.verticalPadding)
             make.centerX.equalToSuperview()
-            make.height.equalTo(GymDetailViewController.ConstraintConstants.titleLabelHeight)
+            make.height.equalTo(Constraints.titleLabelHeight)
         }
 
         if let gymFacilitiesTableView = gymFacilitiesTableView {
@@ -78,9 +78,9 @@ class GymDetailFacilitiesCell: UICollectionViewCell {
             }
 
             dividerView.snp.remakeConstraints { make in
-                make.top.equalTo(gymFacilitiesTableView.snp.bottom).offset(GymDetailViewController.ConstraintConstants.verticalPadding)
+                make.top.equalTo(gymFacilitiesTableView.snp.bottom).offset(Constraints.verticalPadding)
                 make.leading.trailing.equalToSuperview()
-                make.height.equalTo(GymDetailViewController.ConstraintConstants.dividerHeight)
+                make.height.equalTo(Constraints.dividerViewHeight)
             }
         }
     }

--- a/Uplift/Views/GymDetail/GymDetailFacilitiesCell.swift
+++ b/Uplift/Views/GymDetail/GymDetailFacilitiesCell.swift
@@ -13,9 +13,7 @@ class GymDetailFacilitiesCell: UICollectionViewCell {
     // MARK: - Constraint constants
     enum Constants {
         static let gymFacilitiesCellHeight: CGFloat = 20
-        static let gymFacilitiesTopPadding = 12
-        static let facilitiesLabelHeight = 22
-        static let facilitiesLabelTopPadding = 23
+        static let gymFacilitiesTopPadding: CGFloat = 12
     }
 
     // MARK: - Private view vars
@@ -35,7 +33,7 @@ class GymDetailFacilitiesCell: UICollectionViewCell {
     // MARK: - Public configure
     func configure(for gymDetail: GymDetail) {
         gymFacilities = gymDetail.facilities
-        
+
         DispatchQueue.main.async {
             self.gymFacilitiesTableView.reloadData()
             self.setupConstraints()
@@ -43,9 +41,9 @@ class GymDetailFacilitiesCell: UICollectionViewCell {
     }
 
     func setupViews() {
-        facilitiesLabel.font = ._16MontserratMedium
+        facilitiesLabel.font = ._16MontserratBold
         facilitiesLabel.textAlignment = .center
-        facilitiesLabel.textColor = .fitnessBlack
+        facilitiesLabel.textColor = .fitnessLightBlack
         facilitiesLabel.text = "FACILITIES"
         contentView.addSubview(facilitiesLabel)
 
@@ -67,9 +65,9 @@ class GymDetailFacilitiesCell: UICollectionViewCell {
 
     func setupConstraints() {
         facilitiesLabel.snp.makeConstraints { make in
-            make.top.equalToSuperview().inset(Constants.facilitiesLabelTopPadding)
+            make.top.equalToSuperview().inset(GymDetailViewController.ConstraintConstants.verticalPadding)
             make.centerX.equalToSuperview()
-            make.height.equalTo(Constants.facilitiesLabelHeight)
+            make.height.equalTo(GymDetailViewController.ConstraintConstants.titleLabelHeight)
         }
 
         if let gymFacilitiesTableView = gymFacilitiesTableView {
@@ -80,7 +78,7 @@ class GymDetailFacilitiesCell: UICollectionViewCell {
             }
 
             dividerView.snp.remakeConstraints { make in
-                make.top.equalTo(gymFacilitiesTableView.snp.bottom).offset(GymDetailViewController.ConstraintConstants.dividerViewTopPadding)
+                make.top.equalTo(gymFacilitiesTableView.snp.bottom).offset(GymDetailViewController.ConstraintConstants.verticalPadding)
                 make.leading.trailing.equalToSuperview()
                 make.height.equalTo(GymDetailViewController.ConstraintConstants.dividerHeight)
             }

--- a/Uplift/Views/GymDetail/GymDetailHoursCell.swift
+++ b/Uplift/Views/GymDetail/GymDetailHoursCell.swift
@@ -16,12 +16,9 @@ class GymDetailHoursCell: UICollectionViewCell {
 
     // MARK: - Constraint constants
     enum Constants {
-        static let dividerTopPadding = 32
-        static let hoursTableViewDroppedHeight = 181
-        static let hoursTableViewHeight = 19
-        static let hoursTableViewTopPadding = 12
-        static let hoursTitleLabelHeight = 19
-        static let hoursTitleLabelTopPadding = 36
+        static let hoursTableViewDroppedHeight: CGFloat = 181
+        static let hoursTableViewHeight: CGFloat = 19
+        static let hoursTableViewTopPadding: CGFloat = 12
     }
 
     // MARK: - Private data vars
@@ -83,8 +80,8 @@ class GymDetailHoursCell: UICollectionViewCell {
         closedLabel.text = "CLOSED"
         contentView.addSubview(closedLabel)
 
-        hoursTitleLabel.font = ._16MontserratMedium
-        hoursTitleLabel.textColor = .fitnessBlack
+        hoursTitleLabel.font = ._16MontserratBold
+        hoursTitleLabel.textColor = .fitnessLightBlack
         hoursTitleLabel.textAlignment = .center
         hoursTitleLabel.text = "HOURS"
         contentView.addSubview(hoursTitleLabel)
@@ -109,8 +106,8 @@ class GymDetailHoursCell: UICollectionViewCell {
     private func setupConstraints() {
         hoursTitleLabel.snp.updateConstraints { make in
             make.centerX.equalToSuperview()
-            make.top.equalTo(closedLabel.snp.bottom).offset(Constants.hoursTitleLabelTopPadding)
-            make.height.equalTo(Constants.hoursTitleLabelHeight)
+            make.top.equalTo(closedLabel.snp.bottom).offset(GymDetailViewController.ConstraintConstants.verticalPadding)
+            make.height.equalTo(GymDetailViewController.ConstraintConstants.titleLabelHeight)
         }
 
         hoursTableView.snp.updateConstraints { make in
@@ -128,7 +125,7 @@ class GymDetailHoursCell: UICollectionViewCell {
         }
 
         dividerView.snp.updateConstraints {make in
-            make.top.equalTo(hoursTableView.snp.bottom).offset(Constants.dividerTopPadding)
+            make.top.equalTo(hoursTableView.snp.bottom).offset(GymDetailViewController.ConstraintConstants.verticalPadding)
             make.leading.trailing.equalToSuperview()
             make.height.equalTo(GymDetailViewController.ConstraintConstants.dividerHeight)
         }
@@ -141,7 +138,7 @@ class GymDetailHoursCell: UICollectionViewCell {
         if dailyGymHours.openTime != dailyGymHours.closeTime {
             return "\(openTime) - \(closeTime)"
         }
-        
+
         return "Closed"
     }
 

--- a/Uplift/Views/GymDetail/GymDetailHoursCell.swift
+++ b/Uplift/Views/GymDetail/GymDetailHoursCell.swift
@@ -73,13 +73,6 @@ class GymDetailHoursCell: UICollectionViewCell {
 
     // MARK: - Private helpers
     private func setupViews() {
-        closedLabel.font = ._16MontserratSemiBold
-        closedLabel.textColor = .white
-        closedLabel.textAlignment = .center
-        closedLabel.backgroundColor = .fitnessBlack
-        closedLabel.text = "CLOSED"
-        contentView.addSubview(closedLabel)
-
         hoursTitleLabel.font = ._16MontserratBold
         hoursTitleLabel.textColor = .fitnessLightBlack
         hoursTitleLabel.textAlignment = .center
@@ -106,8 +99,8 @@ class GymDetailHoursCell: UICollectionViewCell {
     private func setupConstraints() {
         hoursTitleLabel.snp.updateConstraints { make in
             make.centerX.equalToSuperview()
-            make.top.equalTo(closedLabel.snp.bottom).offset(GymDetailViewController.ConstraintConstants.verticalPadding)
-            make.height.equalTo(GymDetailViewController.ConstraintConstants.titleLabelHeight)
+            make.top.equalToSuperview().offset(Constraints.verticalPadding)
+            make.height.equalTo(Constraints.titleLabelHeight)
         }
 
         hoursTableView.snp.updateConstraints { make in
@@ -125,9 +118,9 @@ class GymDetailHoursCell: UICollectionViewCell {
         }
 
         dividerView.snp.updateConstraints {make in
-            make.top.equalTo(hoursTableView.snp.bottom).offset(GymDetailViewController.ConstraintConstants.verticalPadding)
+            make.top.equalTo(hoursTableView.snp.bottom).offset(Constraints.verticalPadding)
             make.leading.trailing.equalToSuperview()
-            make.height.equalTo(GymDetailViewController.ConstraintConstants.dividerHeight)
+            make.height.equalTo(Constraints.dividerViewHeight)
         }
     }
 

--- a/Uplift/Views/GymDetail/GymDetailPopularTimesCell.swift
+++ b/Uplift/Views/GymDetail/GymDetailPopularTimesCell.swift
@@ -67,8 +67,8 @@ class GymDetailPopularTimesCell: UICollectionViewCell {
     private func setupConstraints() {
         popularTimesLabel.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
-            make.top.equalToSuperview().offset(GymDetailViewController.ConstraintConstants.verticalPadding)
-            make.height.equalTo(GymDetailViewController.ConstraintConstants.titleLabelHeight)
+            make.top.equalToSuperview().offset(Constraints.verticalPadding)
+            make.height.equalTo(Constraints.titleLabelHeight)
         }
 
         if let histogram = popularTimesHistogram {
@@ -81,14 +81,14 @@ class GymDetailPopularTimesCell: UICollectionViewCell {
             }
 
             dividerView.snp.remakeConstraints { make in
-                make.top.equalTo(histogram.snp.bottom).offset(GymDetailViewController.ConstraintConstants.verticalPadding)
-                make.height.equalTo(GymDetailViewController.ConstraintConstants.dividerHeight)
+                make.top.equalTo(histogram.snp.bottom).offset(Constraints.verticalPadding)
+                make.height.equalTo(Constraints.dividerViewHeight)
                 make.leading.trailing.equalToSuperview()
             }
         } else {
             dividerView.snp.makeConstraints { make in
-                make.top.equalTo(popularTimesLabel.snp.bottom).offset(GymDetailViewController.ConstraintConstants.verticalPadding)
-                make.height.equalTo(GymDetailViewController.ConstraintConstants.dividerHeight)
+                make.top.equalTo(popularTimesLabel.snp.bottom).offset(Constraints.verticalPadding)
+                make.height.equalTo(Constraints.dividerViewHeight)
                 make.leading.trailing.equalToSuperview()
             }
         }

--- a/Uplift/Views/GymDetail/GymDetailPopularTimesCell.swift
+++ b/Uplift/Views/GymDetail/GymDetailPopularTimesCell.swift
@@ -12,9 +12,8 @@ class GymDetailPopularTimesCell: UICollectionViewCell {
 
     // MARK: - Constraint constants
     enum Constants {
-        static let popularTimesHistogramHeight = 101
-        static let popularTimesLabelHeight = 19
-        static let popularTimesLabelTopPadding = 24
+        static let popularTimesHistogramHeight: CGFloat = 101
+        static let popularTimesHistogramTopPadding: CGFloat = 24
     }
 
     // MARK: - Private view vars
@@ -49,7 +48,7 @@ class GymDetailPopularTimesCell: UICollectionViewCell {
     // MARK: - Private helpers
     private func setupViews() {
         popularTimesLabel.text = "POPULAR TIMES"
-        popularTimesLabel.font = ._16MontserratMedium
+        popularTimesLabel.font = ._16MontserratBold
         popularTimesLabel.textColor = .fitnessLightBlack
         popularTimesLabel.textAlignment = .center
         contentView.addSubview(popularTimesLabel)
@@ -67,9 +66,9 @@ class GymDetailPopularTimesCell: UICollectionViewCell {
 
     private func setupConstraints() {
         popularTimesLabel.snp.makeConstraints { make in
-            make.leading.trailing.equalToSuperview()
-            make.top.equalToSuperview().offset(Constants.popularTimesLabelTopPadding)
-            make.height.equalTo(Constants.popularTimesLabelHeight)
+            make.centerX.equalToSuperview()
+            make.top.equalToSuperview().offset(GymDetailViewController.ConstraintConstants.verticalPadding)
+            make.height.equalTo(GymDetailViewController.ConstraintConstants.titleLabelHeight)
         }
 
         if let histogram = popularTimesHistogram {
@@ -77,18 +76,18 @@ class GymDetailPopularTimesCell: UICollectionViewCell {
 
             histogram.snp.makeConstraints { make in
                 make.leading.trailing.equalToSuperview().inset(popularTimesHistogramHorizontalPadding)
-                make.top.equalTo(popularTimesLabel.snp.bottom).offset(Constants.popularTimesLabelTopPadding)
+                make.top.equalTo(popularTimesLabel.snp.bottom).offset(Constants.popularTimesHistogramTopPadding)
                 make.height.equalTo(Constants.popularTimesHistogramHeight)
             }
 
             dividerView.snp.remakeConstraints { make in
-                make.top.equalTo(histogram.snp.bottom).offset(GymDetailViewController.ConstraintConstants.dividerViewTopPadding)
+                make.top.equalTo(histogram.snp.bottom).offset(GymDetailViewController.ConstraintConstants.verticalPadding)
                 make.height.equalTo(GymDetailViewController.ConstraintConstants.dividerHeight)
                 make.leading.trailing.equalToSuperview()
             }
         } else {
             dividerView.snp.makeConstraints { make in
-                make.top.equalTo(popularTimesLabel.snp.bottom).offset(GymDetailViewController.ConstraintConstants.dividerViewTopPadding)
+                make.top.equalTo(popularTimesLabel.snp.bottom).offset(GymDetailViewController.ConstraintConstants.verticalPadding)
                 make.height.equalTo(GymDetailViewController.ConstraintConstants.dividerHeight)
                 make.leading.trailing.equalToSuperview()
             }

--- a/Uplift/Views/GymDetail/GymDetailTodaysClassesCell.swift
+++ b/Uplift/Views/GymDetail/GymDetailTodaysClassesCell.swift
@@ -16,11 +16,9 @@ class GymDetailTodaysClassesCell: UICollectionViewCell {
 
     // MARK: - Constraint constants
     enum Constants {
-        static let classesCollectionViewVerticalPadding: CGFloat = 32
+        static let classesCollectionViewVerticalPadding: CGFloat = 34
         static let noMoreClassesLabelHeight: CGFloat = 66
         static let noMoreClassesLabelTopPadding: CGFloat = 22
-        static let todaysClassesLabelHeight: CGFloat = 18
-        static let todaysClassesLabelTopPadding: CGFloat = 24
     }
 
     // MARK: - Private view vars
@@ -53,8 +51,8 @@ class GymDetailTodaysClassesCell: UICollectionViewCell {
 
     // MARK: - Private helpers
     private func setupViews() {
-        todaysClassesLabel.font = ._16MontserratMedium
-        todaysClassesLabel.textColor = .fitnessBlack
+        todaysClassesLabel.font = ._16MontserratBold
+        todaysClassesLabel.textColor = .fitnessLightBlack
         todaysClassesLabel.text = "TODAY'S CLASSES"
         todaysClassesLabel.textAlignment = .center
         contentView.addSubview(todaysClassesLabel)
@@ -85,9 +83,9 @@ class GymDetailTodaysClassesCell: UICollectionViewCell {
 
     private func setupConstraints() {
         todaysClassesLabel.snp.makeConstraints { make in
-            make.top.equalToSuperview().inset(Constants.todaysClassesLabelTopPadding)
+            make.top.equalToSuperview().inset(GymDetailViewController.ConstraintConstants.verticalPadding)
             make.centerX.equalToSuperview()
-            make.height.equalTo(Constants.todaysClassesLabelHeight)
+            make.height.equalTo(GymDetailViewController.ConstraintConstants.titleLabelHeight)
         }
     }
 
@@ -108,7 +106,7 @@ class GymDetailTodaysClassesCell: UICollectionViewCell {
             contentView.addSubview(classesCollectionView)
 
             classesCollectionView.snp.remakeConstraints { make in
-                make.top.equalTo(todaysClassesLabel.snp.bottom).offset(Constants.classesCollectionViewVerticalPadding)
+                make.top.equalTo(todaysClassesLabel.snp.bottom).offset(GymDetailViewController.ConstraintConstants.verticalPadding)
                 make.bottom.equalToSuperview().inset(Constants.classesCollectionViewVerticalPadding)
                 make.left.right.equalToSuperview().inset(classesCollectionViewHorizontalPadding)
                 make.centerX.equalToSuperview()

--- a/Uplift/Views/GymDetail/GymDetailTodaysClassesCell.swift
+++ b/Uplift/Views/GymDetail/GymDetailTodaysClassesCell.swift
@@ -83,9 +83,9 @@ class GymDetailTodaysClassesCell: UICollectionViewCell {
 
     private func setupConstraints() {
         todaysClassesLabel.snp.makeConstraints { make in
-            make.top.equalToSuperview().inset(GymDetailViewController.ConstraintConstants.verticalPadding)
+            make.top.equalToSuperview().inset(Constraints.verticalPadding)
             make.centerX.equalToSuperview()
-            make.height.equalTo(GymDetailViewController.ConstraintConstants.titleLabelHeight)
+            make.height.equalTo(Constraints.titleLabelHeight)
         }
     }
 
@@ -106,7 +106,7 @@ class GymDetailTodaysClassesCell: UICollectionViewCell {
             contentView.addSubview(classesCollectionView)
 
             classesCollectionView.snp.remakeConstraints { make in
-                make.top.equalTo(todaysClassesLabel.snp.bottom).offset(GymDetailViewController.ConstraintConstants.verticalPadding)
+                make.top.equalTo(todaysClassesLabel.snp.bottom).offset(Constraints.verticalPadding)
                 make.bottom.equalToSuperview().inset(Constants.classesCollectionViewVerticalPadding)
                 make.left.right.equalToSuperview().inset(classesCollectionViewHorizontalPadding)
                 make.centerX.equalToSuperview()


### PR DESCRIPTION
This standardizes the spacing above and below the content inside each cell for GymDetail and ClassDetail and moves redundant constant values to Constants.swift. 

**GymDetail**
![Simulator Screen Shot - iPhone 11 Pro - 2019-10-02 at 18 13 09](https://user-images.githubusercontent.com/20599510/66085832-54823d80-e540-11e9-8987-b1b6751004ba.png)
![Simulator Screen Shot - iPhone 11 Pro - 2019-10-02 at 18 13 13](https://user-images.githubusercontent.com/20599510/66085840-577d2e00-e540-11e9-97cf-76bdf7d1f43b.png)

**ClassDetail**
![Simulator Screen Shot - iPhone 11 Pro - 2019-10-03 at 21 41 42](https://user-images.githubusercontent.com/20599510/66175235-c634b700-e626-11e9-81cb-aeb84b839e19.png)


