### PR TITLE
Refactor colors to reflect styleguide

### DIFF
--- a/Uplift/Controllers/ClassListViewController.swift
+++ b/Uplift/Controllers/ClassListViewController.swift
@@ -218,14 +218,15 @@ extension ClassListViewController: UICollectionViewDelegate, UICollectionViewDat
 
             if dateForCell < currDate {
                 dateLabelTextColor = .fitnessMediumGrey
-                dayOfWeekLabelTextColor = .fitnessMediumGrey
+                dayOfWeekLabelTextColor = .gray02
             }
 
             if dateForCell == calendarDateSelected {
                 dateLabelCircleIsHidden = false
-                dateLabelFont = ._12MontserratSemiBold
-                dateLabelTextColor = .white
-                dayOfWeekLabelFont = ._12MontserratSemiBold
+                dateLabelFont = UIFont._12LatoBlack
+                dateLabelTextColor = .gray01
+                dayOfWeekLabelFont = ._12LatoBlack
+                dayOfWeekLabelTextColor = .primaryBlack
             }
 
             cell.configure(for: "\(dayOfMonth)",
@@ -310,7 +311,7 @@ extension ClassListViewController: FilterDelegate {
             currentFilterParams = params
 
             // Modify Button
-            filterButton.backgroundColor = .fitnessYellow
+            filterButton.backgroundColor = .primaryYellow
             filterButton.setTitle(ClientStrings.Filter.appliedFilterLabel, for: .normal)
 
             // MARK: - Fabric
@@ -400,7 +401,7 @@ extension ClassListViewController {
 
         titleLabel = UILabel()
         titleLabel.font = ._24MontserratBold
-        titleLabel.textColor = .fitnessBlack
+        titleLabel.textColor = .primaryBlack
         titleLabel.text = ClientStrings.ClassList.vcTitleLabel
         titleView.addSubview(titleLabel)
 
@@ -412,15 +413,15 @@ extension ClassListViewController {
 
         filterButton = UIButton()
         filterButton.setTitle(ClientStrings.Filter.applyFilterLabel, for: .normal)
-        filterButton.titleLabel?.font = ._14MontserratSemiBold
+        filterButton.titleLabel?.font = ._14MontserratBold
         filterButton.layer.cornerRadius = 24.0
         filterButton.setTitleColor(.black, for: .normal)
-        filterButton.backgroundColor = .white
+        filterButton.backgroundColor = .primaryWhite
         filterButton.addTarget(self, action: #selector(filterPressed), for: .touchUpInside)
-        filterButton.layer.shadowColor = UIColor.fitnessBlack.cgColor
+        filterButton.layer.shadowColor = UIColor.buttonShadow.cgColor
         filterButton.layer.shadowOffset = CGSize(width: 0, height: 2)
-        filterButton.layer.shadowRadius = 2.0
-        filterButton.layer.shadowOpacity = 0.2
+        filterButton.layer.shadowRadius = 4.0
+        filterButton.layer.shadowOpacity = 1.0
         filterButton.layer.masksToBounds = false
         view.addSubview(filterButton)
     }
@@ -429,8 +430,8 @@ extension ClassListViewController {
         let calendarCollectionViewHeight = 47
         let calendarCollectionViewTopPadding = 40
         let classCollectionViewTopPadding = 18
-        let filterButtonBottomPadding = 36
-        let filterButtonSize = CGSize(width: 180, height: 48)
+        let filterButtonBottomPadding = 18
+        let filterButtonSize = CGSize(width: 164, height: 46)
         let titleBottomConstant = -20
         let titleHeightConstant = 26
         let titleLeadingConstant = 24

--- a/Uplift/Controllers/ClassListViewController.swift
+++ b/Uplift/Controllers/ClassListViewController.swift
@@ -217,15 +217,15 @@ extension ClassListViewController: UICollectionViewDelegate, UICollectionViewDat
             var dayOfWeekLabelTextColor: UIColor?
 
             if dateForCell < currDate {
-                dateLabelTextColor = .fitnessMediumGrey
+                dateLabelTextColor = .gray02
                 dayOfWeekLabelTextColor = .gray02
             }
 
             if dateForCell == calendarDateSelected {
                 dateLabelCircleIsHidden = false
-                dateLabelFont = UIFont._12LatoBlack
-                dateLabelTextColor = .gray01
-                dayOfWeekLabelFont = ._12LatoBlack
+                dateLabelFont = ._12MontserratBold
+                dateLabelTextColor = .primaryBlack
+                dayOfWeekLabelFont = ._12MontserratBold
                 dayOfWeekLabelTextColor = .primaryBlack
             }
 

--- a/Uplift/Controllers/FavoritesViewController.swift
+++ b/Uplift/Controllers/FavoritesViewController.swift
@@ -54,7 +54,7 @@ class FavoritesViewController: UIViewController {
 
         titleLabel = UILabel()
         titleLabel.font = ._24MontserratBold
-        titleLabel.textColor = .fitnessBlack
+        titleLabel.textColor = .primaryBlack
         titleLabel.text = ClientStrings.Favorites.vcTitleLabel
         titleBackground.addSubview(titleLabel)
 
@@ -149,7 +149,7 @@ extension FavoritesViewController: ClassListCellDelegate, NavigationDelegate {
         favorites = favorites.filter { $0.classDetailId != classDetailId }
         classesCollectionView.reloadData()
     }
-    
+
     func viewTodaysClasses() {
         guard let classNavigationController = tabBarController?.viewControllers?[1] as? UINavigationController else { return }
         guard let classListViewController = classNavigationController.viewControllers[0] as? ClassListViewController else { return }

--- a/Uplift/Controllers/FilterViewController.swift
+++ b/Uplift/Controllers/FilterViewController.swift
@@ -102,14 +102,14 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
 
         startTimeTitleLabel = UILabel()
         startTimeTitleLabel.sizeToFit()
-        startTimeTitleLabel.font = ._12LatoBlack
+        startTimeTitleLabel.font = ._12MontserratBold
         startTimeTitleLabel.textColor = .gray04
         startTimeTitleLabel.text = ClientStrings.Filter.startTime
         contentView.addSubview(startTimeTitleLabel)
 
         startTimeLabel = UILabel()
         startTimeLabel.sizeToFit()
-        startTimeLabel.font = ._12LatoBlack
+        startTimeLabel.font = ._12MontserratBold
         startTimeLabel.textColor = .gray04
         startTimeLabel.text = startTime + " - " + endTime
         contentView.addSubview(startTimeLabel)
@@ -131,6 +131,10 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
         startTimeSlider.handleColor = .white
         startTimeSlider.handleBorderWidth = 1.0
         startTimeSlider.handleBorderColor = .gray01
+        startTimeSlider.handleShadowColor = .gray02
+        startTimeSlider.handleShadowOffset = CGSize(width: 0, height: 2)
+        startTimeSlider.handleShadowOpacity = 0.6
+        startTimeSlider.handleShadowRadius = 1.0
         startTimeSlider.tintColor = .gray01
         contentView.addSubview(startTimeSlider)
 
@@ -204,7 +208,7 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
         // NAVIGATION BAR
         let titleView = UILabel()
         titleView.text = ClientStrings.Filter.vcTitleLabel
-        titleView.font = ._14LatoBlack
+        titleView.font = ._14MontserratBold
         self.navigationItem.titleView = titleView
 
         // Color Navigation Bar White if Dark Mode
@@ -218,10 +222,16 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
 
         let doneBarButton = UIBarButtonItem(title: ClientStrings.Filter.doneButton, style: .plain, target: self, action: #selector(done))
         doneBarButton.tintColor = .primaryBlack
+        doneBarButton.setTitleTextAttributes([
+            NSAttributedString.Key.font: UIFont._14MontserratMedium as Any
+        ], for: .normal)
         self.navigationItem.rightBarButtonItem = doneBarButton
 
         let resetBarButton = UIBarButtonItem(title: ClientStrings.Filter.resetButton, style: .plain, target: self, action: #selector(reset))
         resetBarButton.tintColor = .primaryBlack
+        resetBarButton.setTitleTextAttributes([
+            NSAttributedString.Key.font: UIFont._14MontserratMedium as Any
+        ], for: .normal)
         self.navigationItem.leftBarButtonItem = resetBarButton
 
         // SCROLL VIEW
@@ -244,7 +254,7 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
 
         // COLLECTION VIEW
         collectionViewTitle = UILabel()
-        collectionViewTitle.font = ._12LatoBlack
+        collectionViewTitle.font = ._12MontserratBold
         collectionViewTitle.textColor = .gray04
         collectionViewTitle.text = ClientStrings.Filter.selectGymSection
         contentView.addSubview(collectionViewTitle)
@@ -270,7 +280,6 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
         gyms = []
 
         NetworkManager.shared.getGymNames { (gyms) in
-
             self.gyms = gyms
             self.gymCollectionView.reloadData()
         }
@@ -394,7 +403,7 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
         let filterParameters = FilterParameters(classNames: [], endTime: maxDate, gymIds: [], instructorNames: [], shouldFilter: false, startTime: minDate, tags: [])
 
         delegate?.filterOptions(params: filterParameters)
-        
+
         dismiss(animated: true, completion: nil)
 
     }

--- a/Uplift/Controllers/FilterViewController.swift
+++ b/Uplift/Controllers/FilterViewController.swift
@@ -97,20 +97,20 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
 
         // START TIME SLIDER SECTION
         fitnessCenterStartTimeDivider = UIView()
-        fitnessCenterStartTimeDivider.backgroundColor = .fitnessLightGrey
+        fitnessCenterStartTimeDivider.backgroundColor = .gray01
         contentView.addSubview(fitnessCenterStartTimeDivider)
 
         startTimeTitleLabel = UILabel()
         startTimeTitleLabel.sizeToFit()
         startTimeTitleLabel.font = ._12LatoBlack
-        startTimeTitleLabel.textColor = .fitnessDarkGrey
+        startTimeTitleLabel.textColor = .gray04
         startTimeTitleLabel.text = ClientStrings.Filter.startTime
         contentView.addSubview(startTimeTitleLabel)
 
         startTimeLabel = UILabel()
         startTimeLabel.sizeToFit()
         startTimeLabel.font = ._12LatoBlack
-        startTimeLabel.textColor = .fitnessDarkGrey
+        startTimeLabel.textColor = .gray04
         startTimeLabel.text = startTime + " - " + endTime
         contentView.addSubview(startTimeLabel)
 
@@ -127,15 +127,15 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
         startTimeSlider.lineHeight = 6.0
         startTimeSlider.hideLabels = true
 
-        startTimeSlider.colorBetweenHandles = .fitnessYellow
+        startTimeSlider.colorBetweenHandles = .primaryYellow
         startTimeSlider.handleColor = .white
         startTimeSlider.handleBorderWidth = 1.0
-        startTimeSlider.handleBorderColor = .fitnessLightGrey
-        startTimeSlider.tintColor = .fitnessLightGrey
+        startTimeSlider.handleBorderColor = .gray01
+        startTimeSlider.tintColor = .gray01
         contentView.addSubview(startTimeSlider)
 
         startTimeClassTypeDivider = UIView()
-        startTimeClassTypeDivider.backgroundColor = .fitnessLightGrey
+        startTimeClassTypeDivider.backgroundColor = .gray01
         contentView.addSubview(startTimeClassTypeDivider)
 
         // CLASS TYPE SECTION
@@ -153,7 +153,7 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
         contentView.addSubview(classTypeDropdown)
 
         classTypeInstructorDivider = UIView()
-        classTypeInstructorDivider.backgroundColor = .fitnessLightGrey
+        classTypeInstructorDivider.backgroundColor = .gray01
         contentView.addSubview(classTypeInstructorDivider)
 
         classTypeDropdownData = DropdownData(completed: false, dropStatus: .up, titles: [])
@@ -182,7 +182,7 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
         contentView.addSubview(instructorDropdown)
 
         instructorDivider = UIView()
-        instructorDivider.backgroundColor = .fitnessLightGrey
+        instructorDivider.backgroundColor = .gray01
         contentView.addSubview(instructorDivider)
 
         instructorDropdownData = DropdownData(completed: false, dropStatus: .up, titles: [])
@@ -211,17 +211,17 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
         if #available(iOS 13, *) {
             navigationItem.standardAppearance = .init()
             navigationItem.compactAppearance = .init()
-            navigationItem.compactAppearance?.backgroundColor = .fitnessWhite
-            navigationItem.standardAppearance?.backgroundColor = .fitnessWhite
-            titleView.textColor = .fitnessBlack
+            navigationItem.compactAppearance?.backgroundColor = .primaryWhite
+            navigationItem.standardAppearance?.backgroundColor = .primaryWhite
+            titleView.textColor = .primaryBlack
         }
 
         let doneBarButton = UIBarButtonItem(title: ClientStrings.Filter.doneButton, style: .plain, target: self, action: #selector(done))
-        doneBarButton.tintColor = .fitnessBlack
+        doneBarButton.tintColor = .primaryBlack
         self.navigationItem.rightBarButtonItem = doneBarButton
 
         let resetBarButton = UIBarButtonItem(title: ClientStrings.Filter.resetButton, style: .plain, target: self, action: #selector(reset))
-        resetBarButton.tintColor = .fitnessBlack
+        resetBarButton.tintColor = .primaryBlack
         self.navigationItem.leftBarButtonItem = resetBarButton
 
         // SCROLL VIEW
@@ -245,7 +245,7 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
         // COLLECTION VIEW
         collectionViewTitle = UILabel()
         collectionViewTitle.font = ._12LatoBlack
-        collectionViewTitle.textColor = .fitnessDarkGrey
+        collectionViewTitle.textColor = .gray04
         collectionViewTitle.text = ClientStrings.Filter.selectGymSection
         contentView.addSubview(collectionViewTitle)
 
@@ -257,7 +257,7 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
 
         gymCollectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         gymCollectionView.allowsMultipleSelection = true
-        gymCollectionView.backgroundColor = .fitnessLightGrey
+        gymCollectionView.backgroundColor = .gray01
         gymCollectionView.isScrollEnabled = true
         gymCollectionView.showsHorizontalScrollIndicator = false
         gymCollectionView.bounces = false
@@ -628,7 +628,7 @@ extension FilterViewController: UITableViewDataSource {
                 cell.titleLabel.text = instructorDropdownData.titles[indexPath.row]
 
                 if selectedInstructors.contains(instructorDropdownData.titles[indexPath.row]) {
-                    cell.checkBoxColoring.backgroundColor = .fitnessYellow
+                    cell.checkBoxColoring.backgroundColor = .primaryYellow
                 }
             }
         } else if tableView == classTypeDropdown {
@@ -636,7 +636,7 @@ extension FilterViewController: UITableViewDataSource {
                 cell.titleLabel.text = classTypeDropdownData.titles[indexPath.row]
 
                 if selectedClasses.contains(classTypeDropdownData.titles[indexPath.row]) {
-                    cell.checkBoxColoring.backgroundColor = .fitnessYellow
+                    cell.checkBoxColoring.backgroundColor = .primaryYellow
                 }
             }
         }
@@ -648,9 +648,9 @@ extension FilterViewController: UITableViewDataSource {
 extension FilterViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let cell = tableView.cellForRow(at: indexPath) as! DropdownViewCell
-        var shouldAppend: Bool = cell.checkBoxColoring.backgroundColor == .fitnessYellow
+        var shouldAppend: Bool = cell.checkBoxColoring.backgroundColor == .primaryYellow
 
-        cell.checkBoxColoring.backgroundColor = shouldAppend ? .white : .fitnessYellow
+        cell.checkBoxColoring.backgroundColor = shouldAppend ? .white : .primaryYellow
         shouldAppend = !shouldAppend
 
         if tableView == classTypeDropdown {

--- a/Uplift/Controllers/HabitTrackingController+Extensions.swift
+++ b/Uplift/Controllers/HabitTrackingController+Extensions.swift
@@ -18,7 +18,7 @@ extension HabitTrackingController: UITableViewDelegate, UITableViewDataSource {
         let title = UILabel()
         title.font = ._14MontserratBold
         title.textAlignment = .left
-        title.textColor = .fitnessDarkGrey
+        title.textColor = .gray04
         header.addSubview(title)
 
         title.snp.makeConstraints { make in

--- a/Uplift/Controllers/HabitTrackingController.swift
+++ b/Uplift/Controllers/HabitTrackingController.swift
@@ -77,7 +77,7 @@ class HabitTrackingController: UIViewController {
     // swiftlint:disable:next function_body_length
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .fitnessWhite
+        view.backgroundColor = .primaryWhite
         tabBarController?.tabBar.isHidden = true
         canSwipe = true
         habits = HabitConstants.suggestedHabits(type: type)
@@ -283,7 +283,7 @@ extension HabitTrackingController {
         titleLabel = UILabel()
         titleLabel.textAlignment = .left
         titleLabel.font = ._36MontserratBold
-        titleLabel.textColor = .fitnessBlack
+        titleLabel.textColor = .primaryBlack
         titleLabel.clipsToBounds = false
         switch type {
         case .cardio:
@@ -301,7 +301,7 @@ extension HabitTrackingController {
         descriptionLabel.text = HabitConstants.habitTypeDescription(type: type)
         descriptionLabel.textAlignment = .left
         descriptionLabel.font = ._16MontserratLight
-        descriptionLabel.textColor = .fitnessBlack
+        descriptionLabel.textColor = .primaryBlack
         descriptionLabel.lineBreakMode = .byWordWrapping
         descriptionLabel.numberOfLines = 0
         contentView.addSubview(descriptionLabel)
@@ -327,8 +327,8 @@ extension HabitTrackingController {
         saveHabitButton = UIButton()
         saveHabitButton.setTitle(ClientStrings.HabitTracking.saveButton, for: .normal)
         saveHabitButton.titleLabel?.font = ._12MontserratBold
-        saveHabitButton.setTitleColor(UIColor.fitnessWhite, for: .normal)
-        saveHabitButton.backgroundColor = .fitnessBlack
+        saveHabitButton.setTitleColor(UIColor.primaryWhite, for: .normal)
+        saveHabitButton.backgroundColor = .primaryBlack
         saveHabitButton.layer.cornerRadius = 30
         saveHabitButton.addTarget(self, action: #selector(doneEditingHabit), for: .touchUpInside)
         view.addSubview(saveHabitButton)

--- a/Uplift/Controllers/HomeViewController.swift
+++ b/Uplift/Controllers/HomeViewController.swift
@@ -48,7 +48,7 @@ class HomeViewController: UIViewController {
 
         sections = [.myGyms, .todaysClasses, .lookingFor]
 
-        view.backgroundColor = UIColor.fitnessWhite
+        view.backgroundColor = UIColor.primaryWhite
 
         setupViews()
         setupConstraints()

--- a/Uplift/Controllers/OnboardingGymsViewController.swift
+++ b/Uplift/Controllers/OnboardingGymsViewController.swift
@@ -38,7 +38,7 @@ class OnboardingGymsViewController: UIViewController, UITableViewDelegate, UITab
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .fitnessWhite
+        view.backgroundColor = .primaryWhite
         let defaults = UserDefaults.standard
         let buttonBorderSize: CGFloat = 2
         
@@ -53,7 +53,7 @@ class OnboardingGymsViewController: UIViewController, UITableViewDelegate, UITab
         titleLabel = UILabel()
         titleLabel.text = ClientStrings.Onboarding.selectGyms
         titleLabel.font = ._24MontserratBold
-        titleLabel.textColor = .fitnessBlack
+        titleLabel.textColor = .primaryBlack
         titleLabel.lineBreakMode = .byWordWrapping
         titleLabel.numberOfLines = 0
         view.addSubview(titleLabel)
@@ -70,8 +70,8 @@ class OnboardingGymsViewController: UIViewController, UITableViewDelegate, UITab
         nextButton = UIButton()
         nextButton.clipsToBounds = false
         nextButton.layer.cornerRadius = nextButtonSize / 2
-        nextButton.backgroundColor = .fitnessYellow
-        nextButton.layer.borderColor = UIColor.fitnessBlack.cgColor
+        nextButton.backgroundColor = .primaryYellow
+        nextButton.layer.borderColor = UIColor.primaryBlack.cgColor
         nextButton.layer.borderWidth = buttonBorderSize
         nextButton.addTarget(self, action: #selector(goToNextView), for: .touchDown)
         nextButton.isEnabled = false
@@ -83,7 +83,7 @@ class OnboardingGymsViewController: UIViewController, UITableViewDelegate, UITab
         backButton = UIButton()
         backButton.clipsToBounds = false
         backButton.layer.cornerRadius = nextButtonSize / 2
-        backButton.backgroundColor = .fitnessWhite
+        backButton.backgroundColor = .primaryWhite
         backButton.layer.borderColor = UIColor.fitnessMediumGrey.cgColor
         backButton.layer.borderWidth = buttonBorderSize
         backButton.addTarget(self, action: #selector(goBackAView), for: .touchDown)

--- a/Uplift/Controllers/OnboardingLoginViewController.swift
+++ b/Uplift/Controllers/OnboardingLoginViewController.swift
@@ -33,34 +33,34 @@ class OnboardingLoginViewController: UIViewController {
     
     let checkSymbolSize: CGFloat = 24
     let checkArrowSize = CGSize(width: 16.95, height: 11.59)
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         
         navigationController?.isNavigationBarHidden = true
         
-        view.backgroundColor = .fitnessWhite
-        
+        view.backgroundColor = .primaryWhite
+
         // Google Sign in
         GIDSignIn.sharedInstance()?.presentingViewController = self
-        
+
         titleLabel = UILabel()
         titleLabel.text = ClientStrings.Onboarding.vcTitleLabel
         titleLabel.font = ._24MontserratBold
-        titleLabel.textColor = .fitnessBlack
+        titleLabel.textColor = .primaryBlack
         titleLabel.lineBreakMode = .byWordWrapping
         titleLabel.numberOfLines = 0
         view.addSubview(titleLabel)
-        
+
         signUpLabel = UILabel()
         signUpLabel.text = ClientStrings.Onboarding.signupLabel
         signUpLabel.font = ._16MontserratBold
-        signUpLabel.textColor = .fitnessBlack
+        signUpLabel.textColor = .primaryBlack
         view.addSubview(signUpLabel)
-        
+
         googleBtn = UIButton()
         googleBtn.titleLabel?.font = ._16MontserratBold
-        googleBtn.setTitleColor(.fitnessLightGrey, for: .normal)
+        googleBtn.setTitleColor(.gray01, for: .normal)
         let googleWhite = UIColor(red: 1, green: 1, blue: 1, alpha: 1)
         let googleBorder = UIColor(red: 0.91, green: 0.91, blue: 0.91, alpha: 1).cgColor
         googleBtn.backgroundColor = googleWhite
@@ -71,11 +71,11 @@ class OnboardingLoginViewController: UIViewController {
         googleBtn.layer.cornerRadius = cornerRadius
         googleBtn.addTarget(self, action: #selector(googleButtonTapped), for: .touchDown)
         view.addSubview(googleBtn)
-        
+
         nextButton = UIButton()
         nextButton.clipsToBounds = false
         nextButton.layer.cornerRadius = nextButtonSize / 2
-        nextButton.backgroundColor = .fitnessWhite
+        nextButton.backgroundColor = .primaryWhite
         nextButton.layer.borderColor = UIColor.fitnessMediumGrey.cgColor
         nextButton.layer.borderWidth = buttonBorderSize
         nextButton.addTarget(self, action: #selector(goToNextView), for: .touchDown)
@@ -84,16 +84,16 @@ class OnboardingLoginViewController: UIViewController {
         nextButtonArrow.transform = CGAffineTransform(rotationAngle: CGFloat(Double.pi))
         nextButton.addSubview(nextButtonArrow)
         view.addSubview(nextButton)
-        
+
         // If already signed in, make Next Button Yellow
         toggleNextButton(enabled: isGoogleSignedIn())
-        
+
         // Check for google sign in
         NotificationCenter.default.addObserver(self, selector: #selector(userSignedInWithGoogle), name: NSNotification.Name("SuccessfulSignInNotification"), object: nil)
-        
+
         setUpConstraints()
     }
-    
+
     // MARK: UI Control
     func setUpConstraints() {
         titleLabel.snp.makeConstraints { make in
@@ -123,13 +123,13 @@ class OnboardingLoginViewController: UIViewController {
             make.size.equalTo(checkArrowSize)
         }
     }
-    
+
     /// Toggles whether the Next button can be pressed (also adds the checkmark in the email field)
     func toggleNextButton(enabled: Bool) {
         if enabled {
             nextButton.isEnabled = true
-            nextButton.backgroundColor = .fitnessYellow
-            nextButton.layer.borderColor = UIColor.fitnessBlack.cgColor
+            nextButton.backgroundColor = .primaryYellow
+            nextButton.layer.borderColor = UIColor.primaryBlack.cgColor
             nextButton.alpha = 1
             nextButtonArrow.alpha = 1
         } else {
@@ -138,15 +138,15 @@ class OnboardingLoginViewController: UIViewController {
             nextButtonArrow.alpha = 0
         }
     }
-    
+
     func displayEmail() {
         /// Changes the google button to display the user's email instead of the google logo
         googleBtn.setImage(nil, for: .normal)
-        googleBtn.contentHorizontalAlignment = .left;
+        googleBtn.contentHorizontalAlignment = .left
         googleBtn.contentEdgeInsets = UIEdgeInsets(top: 0, left: buttonPadding, bottom: 0, right: 0)
         googleBtn.setTitle(User.currentUser?.email, for: .normal)
     }
-    
+
     @objc func goToNextView() {
         if UserDefaults.standard.bool(forKey: Identifiers.hasSeenOnboarding) {
             // Seen Onboarding and had to relogin
@@ -163,7 +163,7 @@ class OnboardingLoginViewController: UIViewController {
         toggleNextButton(enabled: didSignIn)
         googleBtn.isUserInteractionEnabled = !didSignIn
     }
-    
+
     @objc func userSignedInWithGoogle() {
         toggleNextButton(enabled: true)
         signUpLabel.alpha = 0
@@ -171,7 +171,7 @@ class OnboardingLoginViewController: UIViewController {
         googleBtn.isUserInteractionEnabled = false
     }
 
-    // MARK:- Google Sign In
+    // MARK: - Google Sign In
     @objc func googleButtonTapped() {
         if let appDelegate = UIApplication.shared.delegate as? GIDSignInDelegate {
             GIDSignIn.sharedInstance()?.delegate = appDelegate
@@ -180,8 +180,8 @@ class OnboardingLoginViewController: UIViewController {
             GIDSignIn.sharedInstance()?.signIn()
         }
     }
-    
-    // MARK:- Helpers
+
+    // MARK: - Helpers
     private func isGoogleSignedIn() -> Bool {
         return (UIApplication.shared.delegate as! AppDelegate).isGoogleLoggedIn()
     }

--- a/Uplift/Controllers/OnboardingViewController.swift
+++ b/Uplift/Controllers/OnboardingViewController.swift
@@ -68,9 +68,9 @@ class OnboardingViewController: PresentationController {
         button.setTitle(ClientStrings.Onboarding.endOnboarding, for: .normal)
         button.addTarget(self, action: #selector(dismissOnboarding), for: .touchUpInside)
         button.titleLabel?.font = ._14MontserratBold
-        button.setTitleColor(UIColor.fitnessBlack, for: .normal)
+        button.setTitleColor(UIColor.primaryBlack, for: .normal)
 
-        button.backgroundColor = .fitnessYellow
+        button.backgroundColor = .primaryYellow
         button.layer.cornerRadius = 32
         button.layer.shadowOffset = CGSize(width: 0, height: 4)
         button.layer.shadowColor = UIColor.buttonShadow.cgColor

--- a/Uplift/Controllers/TabBarController.swift
+++ b/Uplift/Controllers/TabBarController.swift
@@ -15,8 +15,8 @@ class TabBarController: UITabBarController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        UITabBar.appearance().barTintColor = .fitnessYellow
-        UITabBar.appearance().tintColor = .fitnessBlack
+        UITabBar.appearance().barTintColor = .primaryYellow
+        UITabBar.appearance().tintColor = .primaryBlack
         tabBarItem.setTitleTextAttributes([NSAttributedString.Key.foregroundColor: UIColor.white], for: .normal)
         tabBarItem.setTitleTextAttributes([NSAttributedString.Key.foregroundColor: UIColor.white], for: .selected)
 

--- a/Uplift/Extensions/UIColor+Shared.swift
+++ b/Uplift/Extensions/UIColor+Shared.swift
@@ -10,22 +10,30 @@ import UIKit
 
 extension UIColor {
 
+    @nonobjc static let accentBlue = colorFromCode(0x1395FE)
+    @nonobjc static let accentOrange = colorFromCode(0xFE8F13)
+    @nonobjc static let accentPurple = colorFromCode(0x3813FE)
+    @nonobjc static let accentRed = colorFromCode(0xFE1313)
+    @nonobjc static let accentSeafoam = colorFromCode(0x13FED7)
+    @nonobjc static let accentTurquoise = colorFromCode(0x1395FE)
+
     @nonobjc static let buttonShadow = UIColor(red: 0, green: 0, blue: 0, alpha: 0.2)
-    @nonobjc static let fitnessBlack = UIColor(red: 43/255, green: 43/255, blue: 43/255, alpha: 1.0)
-    @nonobjc static let fitnessClearGrey = UIColor(red: 0, green: 0, blue: 0, alpha: 0.3)
-    @nonobjc static let fitnessDarkGrey = UIColor(red: 112/255, green: 112/255, blue: 112/255, alpha: 1.0)
-    @nonobjc static let fitnessDisabledGrey = UIColor(red: 165/255, green: 165/255, blue: 165/255, alpha: 1.0)
-    @nonobjc static let fitnessGreen = UIColor(red: 100/255, green: 194/255, blue: 112/255, alpha: 1.0)
-    @nonobjc static let fitnessLightGrey = UIColor(red: 216/255, green: 216/255, blue: 216/255, alpha: 1.0)
-    @nonobjc static let fitnessMediumClearGrey = UIColor(red: 39/255, green: 61/255, blue: 82/255, alpha: 0.6)
+
+    @nonobjc static let closedRed = colorFromCode(0xF07D7D)
+
+    @nonobjc static let gray01 = colorFromCode(0xE5ECED)
+    @nonobjc static let gray02 = colorFromCode(0xA1A5A6)
+    @nonobjc static let gray03 = colorFromCode(0xA5A5A5)
+    @nonobjc static let gray04 = colorFromCode(0x707070)
+    @nonobjc static let gray05 = colorFromCode(0x738390)
+
+    @nonobjc static let openGreen = colorFromCode(0x64C270)
+
+    @nonobjc static let primaryBlack = colorFromCode(0x222222)
+    @nonobjc static let primaryWhite = colorFromCode(0xFFFFFF)
+    @nonobjc static let primaryYellow = colorFromCode(0xF8E71C)
+
     @nonobjc static let fitnessMediumGrey = UIColor(red: 206/255, green: 206/255, blue: 206/255, alpha: 1.0)
-    @nonobjc static let fitnessMutedGreen = UIColor(red: 229/255, green: 236/255, blue: 237/255, alpha: 1.0)
-    @nonobjc static let fitnessOrange = colorFromCode(0xFF990E)
-    @nonobjc static let fitnessRed = UIColor(red: 240/255, green: 125/255, blue: 125/255, alpha: 1.0)
-    @nonobjc static let fitnessWhite = UIColor(red: 255/255, green: 255/255, blue: 255/255, alpha: 1.0)
-    @nonobjc static let fitnessYellow = UIColor(red: 248/255, green: 231/255, blue: 28/255, alpha: 1.0)
-    @nonobjc static let fitnessLightBlack = UIColor(red: 34/255, green: 34/255, blue: 34/255, alpha: 1.0)
-    @nonobjc static let fitnessSecondaryBlack = UIColor(red: 85/255, green: 85/255, blue: 85/255, alpha: 1.0)
     @nonobjc static let fitnessSelectedYellow = UIColor(red: 216/255, green: 200/255, blue: 0, alpha: 1.0)
 
     public static func colorFromCode(_ code: Int) -> UIColor {

--- a/Uplift/Extensions/UIColor+Shared.swift
+++ b/Uplift/Extensions/UIColor+Shared.swift
@@ -10,31 +10,33 @@ import UIKit
 
 extension UIColor {
 
+    // MARK: - Accent Colors
     @nonobjc static let accentBlue = colorFromCode(0x1395FE)
+    @nonobjc static let accentClosed = colorFromCode(0xF07D7D)
+    @nonobjc static let accentOpen = colorFromCode(0x64C270)
     @nonobjc static let accentOrange = colorFromCode(0xFE8F13)
     @nonobjc static let accentPurple = colorFromCode(0x3813FE)
     @nonobjc static let accentRed = colorFromCode(0xFE1313)
     @nonobjc static let accentSeafoam = colorFromCode(0x13FED7)
     @nonobjc static let accentTurquoise = colorFromCode(0x1395FE)
 
+    // MARK: - Button Shadow Color
     @nonobjc static let buttonShadow = UIColor(red: 0, green: 0, blue: 0, alpha: 0.2)
 
-    @nonobjc static let closedRed = colorFromCode(0xF07D7D)
-
+    // MARK: - Grays
+    // Used for old designs, to be replaced when views are re-implemented
+    @nonobjc static let fitnessMediumGrey = UIColor(red: 206/255, green: 206/255, blue: 206/255, alpha: 1.0)
     @nonobjc static let gray01 = colorFromCode(0xE5ECED)
     @nonobjc static let gray02 = colorFromCode(0xA1A5A6)
     @nonobjc static let gray03 = colorFromCode(0xA5A5A5)
     @nonobjc static let gray04 = colorFromCode(0x707070)
     @nonobjc static let gray05 = colorFromCode(0x738390)
 
-    @nonobjc static let openGreen = colorFromCode(0x64C270)
-
+    // MARK: - Primary Colors
     @nonobjc static let primaryBlack = colorFromCode(0x222222)
+    @nonobjc static let primaryLightYellow = colorFromCode(0xFCF5A4)
     @nonobjc static let primaryWhite = colorFromCode(0xFFFFFF)
     @nonobjc static let primaryYellow = colorFromCode(0xF8E71C)
-
-    @nonobjc static let fitnessMediumGrey = UIColor(red: 206/255, green: 206/255, blue: 206/255, alpha: 1.0)
-    @nonobjc static let fitnessSelectedYellow = UIColor(red: 216/255, green: 200/255, blue: 0, alpha: 1.0)
 
     public static func colorFromCode(_ code: Int) -> UIColor {
         let red = CGFloat(((code & 0xFF0000) >> 16)) / 255

--- a/Uplift/Helpers/SearchBar.swift
+++ b/Uplift/Helpers/SearchBar.swift
@@ -18,7 +18,7 @@ struct SearchBar {
         searchBar.changeSearchBarColor(color: .white)
 
         let textfield = searchBar.value(forKey: "searchField") as? UITextField
-        textfield?.textColor = UIColor.fitnessBlack
+        textfield?.textColor = UIColor.primaryBlack
         textfield?.font = ._12MontserratRegular
         return searchBar
     }

--- a/Uplift/Legacy/Old Gym Detail View/Controllers/OldGymDetailViewController.swift
+++ b/Uplift/Legacy/Old Gym Detail View/Controllers/OldGymDetailViewController.swift
@@ -101,27 +101,27 @@ class OldGymDetailViewController: UIViewController {
         facilitiesTitleLabel = UILabel()
         facilitiesTitleLabel.font = ._16MontserratMedium
         facilitiesTitleLabel.textAlignment = .center
-        facilitiesTitleLabel.textColor = .fitnessBlack
+        facilitiesTitleLabel.textColor = .primaryBlack
         facilitiesTitleLabel.sizeToFit()
         facilitiesTitleLabel.text = "FACILITIES"
         contentView.addSubview(facilitiesTitleLabel)
 
         setupFacilities()
         facilitiesClassesDivider = UIView()
-        facilitiesClassesDivider.backgroundColor = .fitnessLightGrey
+        facilitiesClassesDivider.backgroundColor = .gray01
         contentView.addSubview(facilitiesClassesDivider)
 
         // CLASSES
         todaysClassesLabel = UILabel()
         todaysClassesLabel.font = ._12LatoBlack
-        todaysClassesLabel.textColor = .fitnessDarkGrey
+        todaysClassesLabel.textColor = .gray04
         todaysClassesLabel.text = "TODAY'S CLASSES"
         todaysClassesLabel.textAlignment = .center
         contentView.addSubview(todaysClassesLabel)
 
         noMoreClassesLabel = UILabel()
         noMoreClassesLabel.font = UIFont._14MontserratLight
-        noMoreClassesLabel.textColor = .fitnessDarkGrey
+        noMoreClassesLabel.textColor = .gray04
         noMoreClassesLabel.text = "We are done for today. \nCheck again tomorrow!\n🌟"
         noMoreClassesLabel.numberOfLines = 0
         noMoreClassesLabel.textAlignment = .center
@@ -200,7 +200,7 @@ class OldGymDetailViewController: UIViewController {
             tempClosedLabel.font = ._16MontserratSemiBold
             tempClosedLabel.textColor = .white
             tempClosedLabel.textAlignment = .center
-            tempClosedLabel.backgroundColor = .fitnessBlack
+            tempClosedLabel.backgroundColor = .primaryBlack
             tempClosedLabel.text = "CLOSED"
             contentView.addSubview(tempClosedLabel)
 
@@ -241,7 +241,7 @@ class OldGymDetailViewController: UIViewController {
         // HOURS
         hoursTitleLabel = UILabel()
         hoursTitleLabel.font = ._16MontserratMedium
-        hoursTitleLabel.textColor = .fitnessBlack
+        hoursTitleLabel.textColor = .primaryBlack
         hoursTitleLabel.textAlignment = .center
         hoursTitleLabel.sizeToFit()
         hoursTitleLabel.text = "HOURS"
@@ -263,7 +263,7 @@ class OldGymDetailViewController: UIViewController {
         contentView.addSubview(hoursTableView)
 
         hoursPopularTimesSeparator = UIView()
-        hoursPopularTimesSeparator.backgroundColor = .fitnessLightGrey
+        hoursPopularTimesSeparator.backgroundColor = .gray01
         contentView.addSubview(hoursPopularTimesSeparator)
 
         days = [.sunday, .monday, .tuesday, .wednesday, .thursday, .friday, .saturday]
@@ -273,7 +273,7 @@ class OldGymDetailViewController: UIViewController {
             popularTimesTitleLabel = UILabel()
             popularTimesTitleLabel?.font = ._16MontserratMedium
             popularTimesTitleLabel?.textAlignment = .center
-            popularTimesTitleLabel?.textColor = .fitnessBlack
+            popularTimesTitleLabel?.textColor = .primaryBlack
             popularTimesTitleLabel?.sizeToFit()
             popularTimesTitleLabel?.text = "BUSY TIMES"
             contentView.addSubview(popularTimesTitleLabel!)
@@ -285,7 +285,7 @@ class OldGymDetailViewController: UIViewController {
             contentView.addSubview(popularTimesHistogram!)
 
             popularTimesFacilitiesSeparator = UIView()
-            popularTimesFacilitiesSeparator?.backgroundColor = .fitnessLightGrey
+            popularTimesFacilitiesSeparator?.backgroundColor = .gray01
             contentView.addSubview(popularTimesFacilitiesSeparator!)
         }
 

--- a/Uplift/Legacy/Old Gym Detail View/Views/GymFacilitiesView.swift
+++ b/Uplift/Legacy/Old Gym Detail View/Views/GymFacilitiesView.swift
@@ -144,11 +144,11 @@ class GymFacilitiesTableView: UIView, UITableViewDataSource, UITableViewDelegate
             addSubview(poolTableView!)
 
             basketballSeparator = UIView()
-            basketballSeparator!.backgroundColor = .fitnessLightGrey
+            basketballSeparator!.backgroundColor = .gray01
             addSubview(basketballSeparator!)
 
             poolSeparator = UIView()
-            poolSeparator!.backgroundColor = .fitnessLightGrey
+            poolSeparator!.backgroundColor = .gray01
             addSubview(poolSeparator!)
 
         case .teagle:

--- a/Uplift/Legacy/Pros/Cells/ProBioBiographyCell.swift
+++ b/Uplift/Legacy/Pros/Cells/ProBioBiographyCell.swift
@@ -44,7 +44,7 @@ class ProBioBiographyCell: UICollectionViewCell {
     // MARK: - Private helpers
     private func setupViews() {
         bioSummary.font = ._20MontserratSemiBold
-        bioSummary.textColor = .fitnessBlack
+        bioSummary.textColor = .primaryBlack
         bioSummary.textAlignment = .center
         bioSummary.isScrollEnabled = false
         bioSummary.isSelectable = false
@@ -53,7 +53,7 @@ class ProBioBiographyCell: UICollectionViewCell {
         contentView.addSubview(bioSummary)
 
         bioTextView.font = ._14MontserratLight
-        bioTextView.textColor = .fitnessLightBlack
+        bioTextView.textColor = .primaryBlack
         bioTextView.textAlignment = .center
         bioTextView.isScrollEnabled = false
         bioTextView.isSelectable = false
@@ -61,7 +61,7 @@ class ProBioBiographyCell: UICollectionViewCell {
         bioTextView.textContainer.lineFragmentPadding = 0
         contentView.addSubview(bioTextView)
 
-        dividerView.backgroundColor = .fitnessMutedGreen
+        dividerView.backgroundColor = .gray01
         contentView.addSubview(dividerView)
     }
 

--- a/Uplift/Legacy/Pros/Cells/ProBioExpertiseCell.swift
+++ b/Uplift/Legacy/Pros/Cells/ProBioExpertiseCell.swift
@@ -46,16 +46,16 @@ class ProBioExpertiseCell: UICollectionViewCell {
         expertiseLabel.text = "EXPERTISE"
         expertiseLabel.font = ._16MontserratMedium
         expertiseLabel.textAlignment = .center
-        expertiseLabel.textColor = .fitnessLightBlack
+        expertiseLabel.textColor = .primaryBlack
         contentView.addSubview(expertiseLabel)
 
         descriptionLabel.font = ._14MontserratLight
         descriptionLabel.numberOfLines = 0
         descriptionLabel.textAlignment = .center
-        descriptionLabel.textColor = .fitnessLightBlack
+        descriptionLabel.textColor = .primaryBlack
         contentView.addSubview(descriptionLabel)
 
-        dividerView.backgroundColor = .fitnessMutedGreen
+        dividerView.backgroundColor = .gray01
         contentView.addSubview(dividerView)
     }
 

--- a/Uplift/Legacy/Pros/Cells/ProBioLinksCell.swift
+++ b/Uplift/Legacy/Pros/Cells/ProBioLinksCell.swift
@@ -51,7 +51,7 @@ class ProBioLinksCell: UICollectionViewCell {
     private func setupViews() {
         linksTitleLabel.text = "FOLLOW ME"
         linksTitleLabel.font = ._12MontserratBold
-        linksTitleLabel.textColor = .fitnessBlack
+        linksTitleLabel.textColor = .primaryBlack
         linksTitleLabel.textAlignment = .center
         linksTitleLabel.sizeToFit()
         contentView.addSubview(linksTitleLabel)

--- a/Uplift/Legacy/Pros/Cells/ProBioRoutinesCell.swift
+++ b/Uplift/Legacy/Pros/Cells/ProBioRoutinesCell.swift
@@ -55,7 +55,7 @@ class ProBioRoutinesCell: UICollectionViewCell {
         routinesLabel.font = ._16MontserratMedium
         routinesLabel.text = "SUGGESTED ROUTINES"
         routinesLabel.textAlignment = .center
-        routinesLabel.textColor = .fitnessLightBlack
+        routinesLabel.textColor = .primaryBlack
         contentView.addSubview(routinesLabel)
 
         let routineFlowLayout = UICollectionViewFlowLayout()

--- a/Uplift/Legacy/Pros/Cells/ProRoutineCollectionViewCell.swift
+++ b/Uplift/Legacy/Pros/Cells/ProRoutineCollectionViewCell.swift
@@ -74,7 +74,7 @@ class ProRoutineCollectionViewCell: UICollectionViewCell {
         contentView.addSubview(addButton)
 
         descriptionTextView.font = ._14MontserratLight
-        descriptionTextView.textColor = .fitnessLightBlack
+        descriptionTextView.textColor = .primaryBlack
         descriptionTextView.textAlignment = .left
         descriptionTextView.isScrollEnabled = false
         descriptionTextView.isSelectable = false
@@ -87,12 +87,12 @@ class ProRoutineCollectionViewCell: UICollectionViewCell {
         contentView.addSubview(routineTypeImage)
 
         routineTypeLabel.font = ._12MontserratRegular
-        routineTypeLabel.textColor = .fitnessSecondaryBlack
+        routineTypeLabel.textColor = .gray04
         routineTypeLabel.textAlignment = .left
         contentView.addSubview(routineTypeLabel)
 
         titleLabel.font = ._16MontserratMedium
-        titleLabel.textColor = .fitnessBlack
+        titleLabel.textColor = .primaryBlack
         titleLabel.textAlignment = .left
         contentView.addSubview(titleLabel)
     }
@@ -144,10 +144,10 @@ class ProRoutineCollectionViewCell: UICollectionViewCell {
 
         layer.cornerRadius = 4.0
         layer.masksToBounds = false
-        layer.borderColor = UIColor.fitnessMutedGreen.cgColor
+        layer.borderColor = UIColor.gray01.cgColor
         layer.borderWidth = 1
 
-        applySketchShadow(color: .fitnessMutedGreen, alpha: 1, x: 0, y: 11, blur: 14, spread: -10)
+        applySketchShadow(color: .gray01, alpha: 1, x: 0, y: 11, blur: 14, spread: -10)
     }
 
     // Function to apply a shadow as specified by Sketch parameters, retrieved from: https://stackoverflow.com/questions/34269399/how-to-control-shadow-spread-and-blur/48489506#48489506

--- a/Uplift/Views/Cells/ClassListCell.swift
+++ b/Uplift/Views/Cells/ClassListCell.swift
@@ -65,14 +65,14 @@ class ClassListCell: UICollectionViewCell {
         primaryTimeLabel = UILabel()
         primaryTimeLabel.font = ._14MontserratMedium
         primaryTimeLabel.textAlignment = .left
-        primaryTimeLabel.textColor = .fitnessBlack
+        primaryTimeLabel.textColor = .primaryBlack
         primaryTimeLabel.sizeToFit()
         contentView.addSubview(primaryTimeLabel)
 
         secondaryTimeLabel = UILabel()
-        secondaryTimeLabel.font = ._12MontserratLight
+        secondaryTimeLabel.font = ._12MontserratRegular
         secondaryTimeLabel.textAlignment = .left
-        secondaryTimeLabel.textColor = .fitnessBlack
+        secondaryTimeLabel.textColor = .primaryBlack
         secondaryTimeLabel.sizeToFit()
         contentView.addSubview(secondaryTimeLabel)
 
@@ -80,20 +80,20 @@ class ClassListCell: UICollectionViewCell {
         classLabel = UILabel()
         classLabel.font = ._16MontserratMedium
         classLabel.textAlignment = .left
-        classLabel.textColor = .fitnessBlack
+        classLabel.textColor = .primaryBlack
         contentView.addSubview(classLabel)
 
         locationLabel = UILabel()
         locationLabel.font = ._12MontserratLight
         locationLabel.textAlignment = .left
-        locationLabel.textColor = .fitnessBlack
+        locationLabel.textColor = .primaryBlack
         locationLabel.sizeToFit()
         contentView.addSubview(locationLabel)
 
         instructorLabel = UILabel()
         instructorLabel.font = ._12MontserratRegular
         instructorLabel.textAlignment = .left
-        instructorLabel.textColor = .fitnessDarkGrey
+        instructorLabel.textColor = .gray02
         instructorLabel.sizeToFit()
         contentView.addSubview(instructorLabel)
 
@@ -118,17 +118,14 @@ class ClassListCell: UICollectionViewCell {
 
         contentView.layer.cornerRadius = 5
         contentView.layer.backgroundColor = UIColor.white.cgColor
-        contentView.layer.borderColor = UIColor.fitnessLightGrey.cgColor
+        contentView.layer.borderColor = UIColor.gray01.cgColor
         contentView.layer.borderWidth = 0.5
 
-        contentView.layer.shadowColor = UIColor.fitnessBlack.cgColor
-        contentView.layer.shadowOffset = CGSize(width: 0.0, height: 10.0)
-        contentView.layer.shadowRadius = 5.0
-        contentView.layer.shadowOpacity = 0.2
+        contentView.layer.shadowColor = UIColor.gray01.cgColor
+        contentView.layer.shadowOffset = CGSize(width: 0.0, height: 11.0)
+        contentView.layer.shadowRadius = 7.0
+        contentView.layer.shadowOpacity = 0.25
         contentView.layer.masksToBounds = false
-        let shadowFrame = contentView.frame.inset(by: UIEdgeInsets(top: 0, left: 5, bottom: 15, right: 5))
-        contentView.layer.shadowPath = UIBezierPath(roundedRect: shadowFrame, cornerRadius: 5).cgPath
-
     }
 
     // MARK: - CONSTRAINTS

--- a/Uplift/Views/Cells/DropdownViewCell.swift
+++ b/Uplift/Views/Cells/DropdownViewCell.swift
@@ -27,14 +27,14 @@ class DropdownViewCell: UITableViewCell {
         titleLabel = UILabel()
         titleLabel.sizeToFit()
         titleLabel.font = ._14MontserratLight
-        titleLabel.textColor = .fitnessBlack
+        titleLabel.textColor = .primaryBlack
         titleLabel.text = ""
         addSubview(titleLabel)
 
         // CHECKBOX
         checkBox = UIView()
         checkBox.layer.cornerRadius = 3
-        checkBox.layer.borderColor = UIColor.fitnessLightGrey.cgColor
+        checkBox.layer.borderColor = UIColor.gray04.cgColor
         checkBox.layer.borderWidth = 0.5
         checkBox.layer.masksToBounds = false
         addSubview(checkBox)

--- a/Uplift/Views/Cells/DropdownViewCell.swift
+++ b/Uplift/Views/Cells/DropdownViewCell.swift
@@ -58,21 +58,21 @@ class DropdownViewCell: UITableViewCell {
     // MARK: - CONSTRAINTS
     func setupConstraints() {
         titleLabel.snp.updateConstraints { make in
-            make.left.equalToSuperview().offset(16)
+            make.leading.equalToSuperview().offset(16)
             make.top.equalToSuperview()
             make.bottom.equalToSuperview().offset(-16)
         }
 
         checkBox.snp.updateConstraints { make in
             make.top.equalToSuperview().offset(2)
-            make.right.equalToSuperview().offset(-34)
-            make.left.equalTo(checkBox.snp.right).offset(-20)
+            make.trailing.equalToSuperview().offset(-23)
+            make.width.equalTo(20)
             make.bottom.equalToSuperview().offset(-10)
         }
 
         checkBoxColoring.snp.updateConstraints { make in
-            make.top.left.equalToSuperview().offset(3)
-            make.bottom.right.equalToSuperview().offset(-3)
+            make.top.leading.equalToSuperview().offset(3)
+            make.bottom.trailing.equalToSuperview().offset(-3)
         }
     }
 }

--- a/Uplift/Views/Cells/FacilityHoursCell.swift
+++ b/Uplift/Views/Cells/FacilityHoursCell.swift
@@ -30,7 +30,7 @@ class FacilityHoursCell: UITableViewCell {
         contentView.addSubview(hoursScrollView)
 
         hoursLabel.font = ._16MontserratLight
-        hoursLabel.textColor = .fitnessBlack
+        hoursLabel.textColor = .primaryBlack
         hoursLabel.textAlignment = .left
         hoursLabel.sizeToFit()
         hoursLabel.text = "6: 00 AM - 9: 00 PM"
@@ -47,7 +47,7 @@ class FacilityHoursCell: UITableViewCell {
     // MARK: - Private helpers
     func setupViews() {
         dayLabel.font = UIFont._12MontserratBold
-        dayLabel.textColor = .fitnessBlack
+        dayLabel.textColor = .primaryBlack
         dayLabel.textAlignment = .left
         dayLabel.sizeToFit()
         dayLabel.text = "MON"

--- a/Uplift/Views/Cells/FavoriteGymCell.swift
+++ b/Uplift/Views/Cells/FavoriteGymCell.swift
@@ -9,91 +9,91 @@
 import UIKit
 
 class FavoriteGymCell: UITableViewCell {
-    
+
     // MARK: Initialization
     var cellBackground: UIView!
     var gymLabel: UILabel!
     var checkBackground: UIView!
     var checkImage: UIImageView!
-    
+
     // Whether it is in a selected state
     var isOn = false
-    
+
     // Padding and Sizing
     let checkSize: CGFloat = 24
     let checkBorderWidth: CGFloat = 1
     let leftPadding: CGFloat = 15
     let rightPadding: CGFloat = 16
-    
+
     // Reuse Identfier
     static let reuseIdentifier = "gymsTableView"
-    
+
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         self.selectionStyle = .none
         self.contentView.backgroundColor = .white
-        
+
         cellBackground = UIView()
-        cellBackground.backgroundColor =  .fitnessWhite
+        cellBackground.backgroundColor =  .primaryWhite
         cellBackground.layer.cornerRadius = 6
         cellBackground.layer.borderWidth = checkBorderWidth
-        cellBackground.layer.borderColor = UIColor.fitnessLightGrey.cgColor
+        cellBackground.layer.borderColor = UIColor.gray01.cgColor
         // Shadow
         cellBackground.layer.shadowOpacity = 0.125
         cellBackground.layer.shadowRadius = 6
         cellBackground.layer.shadowOffset = CGSize(width: 1, height: 3)
-        
+
         contentView.addSubview(cellBackground)
-        
+
         gymLabel = UILabel()
         gymLabel.font = ._16MontserratMedium
         gymLabel.textColor = .fitnessMediumGrey
         cellBackground.addSubview(gymLabel)
-        
+
         checkBackground = UIView()
-        checkBackground.tintColor = .fitnessWhite
+        checkBackground.tintColor = .primaryWhite
         checkBackground.layer.borderColor = UIColor.fitnessMediumGrey.cgColor
         checkBackground.layer.borderWidth = 1
         checkBackground.layer.cornerRadius = checkSize / 2
         cellBackground.addSubview(checkBackground)
-        
+
         checkImage = UIImageView(image: UIImage(named: "green check"))
         checkImage.alpha = 0
         checkBackground.addSubview(checkImage)
-        
+
         setUpConstraints()
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     override func awakeFromNib() {
         super.awakeFromNib()
         // Initialization code
     }
-    
+
     func configure(with gymName: String) {
         gymLabel.text = gymName
     }
     
     func setUpConstraints() {
-        
+
         cellBackground.snp.makeConstraints { (make) in
             make.leading.trailing.top.bottom.equalToSuperview()
         }
-        
+
         gymLabel.snp.makeConstraints { (make) in
             make.leading.equalToSuperview().inset(leftPadding)
             make.centerY.equalToSuperview()
         }
-        
+
         checkBackground.snp.makeConstraints { (make) in
             make.size.equalTo(checkSize)
             make.trailing.equalToSuperview().inset(rightPadding)
             make.centerY.equalToSuperview()
         }
-        
+
         checkImage.snp.makeConstraints { (make) in
             make.size.equalTo(checkSize + 1)
             make.center.equalToSuperview()
@@ -103,7 +103,7 @@ class FavoriteGymCell: UITableViewCell {
     func toggleSelectedView(selected: Bool) {
         isOn = selected
         if selected {
-            gymLabel.textColor = .fitnessBlack
+            gymLabel.textColor = .primaryBlack
             checkImage.alpha = 1
             checkBackground.layer.borderWidth = 0
         } else {

--- a/Uplift/Views/Cells/GymFacilitiesCell.swift
+++ b/Uplift/Views/Cells/GymFacilitiesCell.swift
@@ -17,11 +17,11 @@ class GymFacilitiesCell: UITableViewCell {
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-        contentView.backgroundColor = .fitnessWhite
+        contentView.backgroundColor = .primaryWhite
 
         facilityLabel.font = ._14MontserratLight
         facilityLabel.textAlignment = .center
-        facilityLabel.textColor = .fitnessLightBlack
+        facilityLabel.textColor = .primaryBlack
         contentView.addSubview(facilityLabel)
 
         setUpConstraints()

--- a/Uplift/Views/Cells/GymFilterCell.swift
+++ b/Uplift/Views/Cells/GymFilterCell.swift
@@ -18,11 +18,11 @@ class GymFilterCell: UICollectionViewCell {
     override var isSelected: Bool {
         didSet {
             if self.isSelected {
-                gymNameLabel.font = ._14MontserratBold
-                selectedCircle.backgroundColor = .fitnessYellow
+                gymNameLabel.font = ._14MontserratSemiBold
+                selectedCircle.backgroundColor = .primaryYellow
             } else {
                 gymNameLabel.font = ._14MontserratRegular
-                selectedCircle.backgroundColor = .white
+                selectedCircle.backgroundColor = .primaryWhite
             }
         }
     }
@@ -32,8 +32,8 @@ class GymFilterCell: UICollectionViewCell {
         backgroundColor = .white
 
         gymNameLabel = UILabel()
-        gymNameLabel.font = ._14MontserratRegular
-        gymNameLabel.textColor = .fitnessBlack
+        gymNameLabel.font = ._14MontserratLight
+        gymNameLabel.textColor = .primaryBlack
         gymNameLabel.sizeToFit()
         gymNameLabel.textAlignment = .center
         contentView.addSubview(gymNameLabel)
@@ -41,7 +41,7 @@ class GymFilterCell: UICollectionViewCell {
         selectedCircle = UIView()
         selectedCircle.clipsToBounds = true
         selectedCircle.layer.cornerRadius = 3
-        selectedCircle.backgroundColor = .white
+        selectedCircle.backgroundColor = .primaryWhite
         contentView.addSubview(selectedCircle)
 
         isSelected = false

--- a/Uplift/Views/Cells/GymHoursCell.swift
+++ b/Uplift/Views/Cells/GymHoursCell.swift
@@ -20,16 +20,16 @@ class GymHoursCell: UITableViewCell {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
 
         hoursLabel = UILabel()
-        hoursLabel.font = ._16MontserratLight
-        hoursLabel.textColor = .fitnessBlack
+        hoursLabel.font = ._16MontserratRegular
+        hoursLabel.textColor = .primaryBlack
         hoursLabel.textAlignment = .center
         hoursLabel.sizeToFit()
         hoursLabel.text = "6: 00 AM - 9: 00 PM"
         contentView.addSubview(hoursLabel)
 
         dayLabel = UILabel()
-        dayLabel.font = ._14MontserratMedium
-        dayLabel.textColor = .fitnessBlack
+        dayLabel.font = ._16MontserratMedium
+        dayLabel.textColor = .primaryBlack
         dayLabel.sizeToFit()
         dayLabel.text = DayAbbreviations.thursday
         contentView.addSubview(dayLabel)
@@ -50,7 +50,7 @@ class GymHoursCell: UITableViewCell {
         }
 
         dayLabel.snp.updateConstraints { make in
-            make.right.equalTo(hoursLabel.snp.left).offset(-4)
+            make.right.equalTo(hoursLabel.snp.left).offset(-8)
             make.top.equalToSuperview()
             make.height.equalTo(18)
         }

--- a/Uplift/Views/Cells/HabitTrackerOnboardingCell.swift
+++ b/Uplift/Views/Cells/HabitTrackerOnboardingCell.swift
@@ -21,24 +21,24 @@ protocol HabitTrackerOnboardingDelegate: class {
 private enum FileConstants {
     static let normalDotsLeadingPadding = 35
     static let swipedDotsLeadingPadding = 15
-    
+
     static let editingTitleLabelTrailingPadding = 50
     static let normalTitleLabelTrailingPadding = 21
     static let swipedTitleLabelTrailingPadding = 145
 }
 
 class HabitTrackerOnboardingCell: UITableViewCell {
-    
+
     // MARK: - INITIALIZATION
     static let height = 54
     static let identifier = Identifiers.habitTrackerOnboardingCell
-    
+
     weak var delegate: HabitTrackerOnboardingDelegate!
 
     private var dotsImage: UIImageView!
     var titleLabel: UITextField!
     var separator: UIView!
-    
+
     private var trashButton: UIButton!
     private var editButton: UIButton!
     private var pinButton: UIButton!
@@ -51,7 +51,7 @@ class HabitTrackerOnboardingCell: UITableViewCell {
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
-        
+   
         // SWIPE INTERACTIONS
         isUserInteractionEnabled = true
         let swipeLeft = UISwipeGestureRecognizer(target: self, action: #selector(self.swipeLeft))
@@ -61,48 +61,48 @@ class HabitTrackerOnboardingCell: UITableViewCell {
         let swipeRight = UISwipeGestureRecognizer(target: self, action: #selector(self.swipeRight))
         swipeRight.direction = .right
         addGestureRecognizer(swipeRight)
-        
+   
         // DRAG ICON
         dotsImage = UIImageView(image: UIImage(named: "drag-icon"))
         contentView.addSubview(dotsImage)
-        
+   
         // TITLE LABEL
         titleLabel = UITextField()
         titleLabel.font = ._16MontserratMedium
         titleLabel.textAlignment = .left
-        titleLabel.textColor = .fitnessBlack
+        titleLabel.textColor = .primaryBlack
         titleLabel.sizeToFit()
         titleLabel.delegate = self
         titleLabel.textDropDelegate = self
         titleLabel.keyboardType = .alphabet
         contentView.addSubview(titleLabel)
-        
+   
         // SEPARATOR
         separator = UIView()
-        separator.backgroundColor = .fitnessLightGrey
+        separator.backgroundColor = .gray01
         contentView.addSubview(separator)
-        
+   
         // BUTTONS
         trashButton = UIButton()
         trashButton.setImage(UIImage(named: "trash-icon"), for: .normal)
         trashButton.addTarget(self, action: #selector(deleteCell), for: .touchUpInside)
         contentView.addSubview(trashButton)
-        
+   
         editButton = UIButton()
         editButton.setImage(UIImage(named: "edit-icon"), for: .normal)
         editButton.addTarget(self, action: #selector(edit), for: .touchUpInside)
         contentView.addSubview(editButton)
-        
+   
         pinButton = UIButton()
         pinButton.setImage(UIImage(named: "pin-icon"), for: .normal)
         pinButton.addTarget(self, action: #selector(pin), for: .touchUpInside)
         contentView.addSubview(pinButton)
-        
+   
         clearTextButton = UIButton()
         clearTextButton.setImage(UIImage(named: "keyboard-cancel"), for: .normal)
         clearTextButton.addTarget(self, action: #selector(clearText), for: .touchUpInside)
         contentView.addSubview(clearTextButton)
-        
+   
         isSwiped = false
         canEdit = false
         editingTitle = false
@@ -110,19 +110,19 @@ class HabitTrackerOnboardingCell: UITableViewCell {
         editButton.isHidden = true
         pinButton.isHidden = true
         clearTextButton.isHidden = true
-        
+   
         setupConstraints()
     }
-    
+
     override func prepareForReuse() {
         super.prepareForReuse()
         separator.isHidden = false
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     // MARK: - CONSTRAINTS
     private func setupConstraints() {
         let buttonSize = 38
@@ -130,151 +130,151 @@ class HabitTrackerOnboardingCell: UITableViewCell {
         let buttonTrailingPadding = 16
         let separatorHeight = 1
         let separatorInset = 24
-        
+
         dotsImage.snp.makeConstraints { make in
             make.leading.equalToSuperview().offset(FileConstants.normalDotsLeadingPadding)
             make.width.equalTo(8)
             make.height.equalTo(14)
             make.centerY.equalToSuperview()
         }
-        
+
         titleLabel.snp.makeConstraints { make in
             make.leading.equalTo(dotsImage.snp.trailing).offset(10)
             make.height.equalTo(18)
             make.centerY.equalToSuperview()
             make.trailing.equalToSuperview().inset(FileConstants.normalTitleLabelTrailingPadding)
         }
-        
+
         pinButton.snp.makeConstraints { make in
             make.width.height.equalTo(buttonSize)
             make.trailing.equalToSuperview().inset(buttonTrailingPadding)
             make.centerY.equalToSuperview()
         }
-        
+
         editButton.snp.makeConstraints { make in
             make.width.height.equalTo(buttonSize)
             make.trailing.equalTo(pinButton.snp.leading).offset(-buttonSpacing)
             make.centerY.equalToSuperview()
         }
-        
+
         trashButton.snp.makeConstraints { make in
             make.width.height.equalTo(buttonSize)
             make.trailing.equalTo(editButton.snp.leading).offset(-buttonSpacing)
             make.centerY.equalToSuperview()
         }
-        
+
         clearTextButton.snp.makeConstraints { make in
             make.height.width.equalTo(28)
             make.trailing.equalToSuperview().inset(buttonTrailingPadding)
             make.centerY.equalToSuperview()
         }
-        
+
         separator.snp.makeConstraints { make in
             make.height.equalTo(separatorHeight)
             make.leading.trailing.equalToSuperview().inset(separatorInset)
             make.bottom.equalToSuperview()
         }
     }
-    
+
     private func updateConstraintsLeftSwipe() {
         dotsImage.snp.updateConstraints { make in
             make.leading.equalToSuperview().inset(FileConstants.swipedDotsLeadingPadding)
         }
-        
+
         titleLabel.snp.updateConstraints { make in
             make.trailing.equalToSuperview().inset(FileConstants.swipedTitleLabelTrailingPadding)
         }
     }
-    
+
     private func updateConstraintsRightSwipe() {
         dotsImage.snp.updateConstraints { make in
             make.leading.equalToSuperview().inset(FileConstants.normalDotsLeadingPadding)
         }
-        
+
         titleLabel.snp.updateConstraints { make in
             make.trailing.equalToSuperview().inset(FileConstants.normalTitleLabelTrailingPadding)
         }
     }
-    
+
     private func updateConstraintsEdit() {
         titleLabel.snp.updateConstraints { make in
             make.trailing.equalToSuperview().inset(FileConstants.editingTitleLabelTrailingPadding)
         }
     }
-    
+
     func setTitle(activity: String) {
         titleLabel.text = activity
     }
-    
+
     // MARK: - BUTTON AND GESTURE METHODS
     @objc func swipeLeft() {
         // Unless a cell is editing, the swipe will succeed
         // If something else is swiped, they will be unswiped by the delegate
         if !isSwiped && delegate?.swipeLeft(cell: self) ?? false {
-            
+
             UIView.animate(withDuration: 0.1, delay: 0.0, options: .curveLinear, animations: {
                 self.dotsImage.frame.origin.x = self.dotsImage.frame.minX - 15
                 self.titleLabel.frame.origin.x = self.titleLabel.frame.minX - 15
-                
+
                 self.trashButton.isHidden = false
                 self.editButton.isHidden = false
                 self.pinButton.isHidden = false
-                
+
                 self.updateConstraintsLeftSwipe()
             }, completion: nil)
-            
+
             isSwiped = true
         }
     }
-    
+
     @objc func swipeRight() {
         if isSwiped && !editingTitle {
             delegate?.swipeRight()
             UIView.animate(withDuration: 0.1, delay: 0.0, options: .curveLinear, animations: {
                 self.dotsImage.frame.origin.x = self.dotsImage.frame.minX + 15
                 self.titleLabel.frame.origin.x = self.titleLabel.frame.minX + 15
-                
+
                 self.trashButton.isHidden = true
                 self.editButton.isHidden = true
                 self.pinButton.isHidden = true
                 self.clearTextButton.isHidden = true
-                
+
                 self.updateConstraintsRightSwipe()
             }, completion: nil)
-            
+
             isSwiped = false
         }
     }
-    
+
     @objc func deleteCell() {
         delegate?.deleteCell(cell: self)
     }
-    
+
     @objc func edit() {
         trashButton.isHidden = true
         editButton.isHidden = true
         pinButton.isHidden = true
         clearTextButton.isHidden = false
-        
+
         updateConstraintsEdit()
-        
+
         canEdit = true
         editingTitle = true
         delegate?.prepareForEditing(cell: self)
         titleLabel.becomeFirstResponder()
     }
-    
+
     func finishEdit(){
         editingTitle = false
         canEdit = false
         titleLabel.resignFirstResponder()
         swipeRight()
     }
-    
+
     @objc func pin() {
         delegate?.featureHabit(cell: self)
     }
-    
+
     @objc func clearText() {
         titleLabel.text = ""
     }
@@ -285,7 +285,7 @@ extension HabitTrackerOnboardingCell: UITextFieldDelegate {
     func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
         return canEdit
     }
-    
+
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         delegate?.endEditing()
         return true

--- a/Uplift/Views/ClassDetail/ClassDetailDescriptionCell.swift
+++ b/Uplift/Views/ClassDetail/ClassDetailDescriptionCell.swift
@@ -39,8 +39,8 @@ class ClassDetailDescriptionCell: UICollectionViewCell {
     // MARK: - Private helpers
     private func setupViews() {
         descriptionTextView.font = ._14MontserratLight
-        descriptionTextView.backgroundColor = .fitnessWhite
-        descriptionTextView.textColor = .fitnessBlack
+        descriptionTextView.backgroundColor = .primaryWhite
+        descriptionTextView.textColor = .primaryBlack
         descriptionTextView.isEditable = false
         descriptionTextView.textAlignment = .center
         descriptionTextView.isScrollEnabled = false
@@ -49,7 +49,7 @@ class ClassDetailDescriptionCell: UICollectionViewCell {
         contentView.addSubview(descriptionTextView)
         descriptionTextView.sizeToFit()
 
-        dividerView.backgroundColor = .fitnessMutedGreen
+        dividerView.backgroundColor = .gray01
         contentView.addSubview(dividerView)
     }
 

--- a/Uplift/Views/ClassDetail/ClassDetailFunctionCell.swift
+++ b/Uplift/Views/ClassDetail/ClassDetailFunctionCell.swift
@@ -44,16 +44,16 @@ class ClassDetailFunctionCell: UICollectionViewCell {
         functionLabel.text = ClientStrings.ClassDetail.functionLabel
         functionLabel.font = ._16MontserratBold
         functionLabel.textAlignment = .center
-        functionLabel.textColor = .fitnessLightBlack
+        functionLabel.textColor = .primaryBlack
         contentView.addSubview(functionLabel)
 
         descriptionLabel.font = ._14MontserratLight
         descriptionLabel.numberOfLines = 0
         descriptionLabel.textAlignment = .center
-        descriptionLabel.textColor = .fitnessBlack
+        descriptionLabel.textColor = .primaryBlack
         contentView.addSubview(descriptionLabel)
 
-        dividerView.backgroundColor = .fitnessMutedGreen
+        dividerView.backgroundColor = .gray01
         contentView.addSubview(dividerView)
     }
 

--- a/Uplift/Views/ClassDetail/ClassDetailHeaderView.swift
+++ b/Uplift/Views/ClassDetail/ClassDetailHeaderView.swift
@@ -66,26 +66,26 @@ class ClassDetailHeaderView: UICollectionReusableView {
         semicircleImageView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(semicircleImageView)
 
-        titleLabel.font = ._36MontserratBold
+        titleLabel.font = ._48Bebas
         titleLabel.lineBreakMode = .byWordWrapping
         titleLabel.numberOfLines = 0
         titleLabel.textAlignment = .center
-        titleLabel.textColor = .white
+        titleLabel.textColor = .primaryWhite
         addSubview(titleLabel)
 
-        locationButton.setTitleColor(.white, for: .normal)
-        locationButton.titleLabel?.font = ._14MontserratLight
+        locationButton.setTitleColor(.primaryWhite, for: .normal)
+        locationButton.titleLabel?.font = ._14MontserratRegular
         locationButton.titleLabel?.textAlignment = .center
         locationButton.addTarget(self, action: #selector(locationSelected), for: .touchUpInside)
         addSubview(locationButton)
 
         instructorButton.titleLabel?.font = ._16MontserratBold
         instructorButton.titleLabel?.textAlignment = .center
-        instructorButton.setTitleColor(.white, for: .normal)
+        instructorButton.setTitleColor(.primaryWhite, for: .normal)
         instructorButton.addTarget(self, action: #selector(instructorSelected), for: .touchUpInside)
         addSubview(instructorButton)
 
-        durationLabel.font = ._18Bebas
+        durationLabel.font = ._14MontserratBold
         durationLabel.textAlignment = .center
         durationLabel.textColor = .primaryBlack
         addSubview(durationLabel)
@@ -93,7 +93,7 @@ class ClassDetailHeaderView: UICollectionReusableView {
 
     private func setupConstraints() {
         let durationLabelBottomPadding = 5
-        let durationLabelSize = CGSize(width: 50, height: 21)
+        let durationLabelSize = CGSize(width: 52, height: 18)
         let instructorButtonHeight = 21
         let instructorButtonTopPadding = 20
         let locationButtonHeight = 16

--- a/Uplift/Views/ClassDetail/ClassDetailHeaderView.swift
+++ b/Uplift/Views/ClassDetail/ClassDetailHeaderView.swift
@@ -87,7 +87,7 @@ class ClassDetailHeaderView: UICollectionReusableView {
 
         durationLabel.font = ._18Bebas
         durationLabel.textAlignment = .center
-        durationLabel.textColor = .fitnessBlack
+        durationLabel.textColor = .primaryBlack
         addSubview(durationLabel)
     }
 

--- a/Uplift/Views/ClassDetail/ClassDetailNextSessionsCell.swift
+++ b/Uplift/Views/ClassDetail/ClassDetailNextSessionsCell.swift
@@ -55,7 +55,7 @@ class ClassDetailNextSessionsCell: UICollectionViewCell {
     // MARK: - Private helpers
     private func setupViews() {
         nextSessionsLabel.font = ._16MontserratBold
-        nextSessionsLabel.textColor = .fitnessLightBlack
+        nextSessionsLabel.textColor = .primaryBlack
         nextSessionsLabel.text = ClientStrings.ClassDetail.nextSessionsLabel
         nextSessionsLabel.textAlignment = .center
         nextSessionsLabel.sizeToFit()

--- a/Uplift/Views/ClassDetail/ClassDetailTimeCell.swift
+++ b/Uplift/Views/ClassDetail/ClassDetailTimeCell.swift
@@ -65,13 +65,13 @@ class ClassDetailTimeCell: UICollectionViewCell {
     private func setupViews() {
         dateLabel.font = ._16MontserratLight
         dateLabel.textAlignment = .center
-        dateLabel.textColor = .fitnessLightBlack
+        dateLabel.textColor = .primaryBlack
         dateLabel.sizeToFit()
         contentView.addSubview(dateLabel)
 
         timeLabel.font = ._16MontserratMedium
         timeLabel.textAlignment = .center
-        timeLabel.textColor = .fitnessLightBlack
+        timeLabel.textColor = .primaryBlack
         timeLabel.sizeToFit()
         contentView.addSubview(timeLabel)
 
@@ -82,12 +82,12 @@ class ClassDetailTimeCell: UICollectionViewCell {
         addToCalendarLabel.text = ClientStrings.ClassDetail.addToCalendarButton
         addToCalendarLabel.font = ._8SFLight
         addToCalendarLabel.textAlignment = .center
-        addToCalendarLabel.textColor = .fitnessLightBlack
+        addToCalendarLabel.textColor = .primaryBlack
         addToCalendarLabel.sizeToFit()
         addToCalendarButton.addTarget(self, action: #selector(addToCalendar), for: .touchUpInside)
         contentView.addSubview(addToCalendarLabel)
 
-        dividerView.backgroundColor = .fitnessMutedGreen
+        dividerView.backgroundColor = .gray01
         contentView.addSubview(dividerView)
     }
 

--- a/Uplift/Views/ClassDetail/ClassDetailTimeCell.swift
+++ b/Uplift/Views/ClassDetail/ClassDetailTimeCell.swift
@@ -80,7 +80,7 @@ class ClassDetailTimeCell: UICollectionViewCell {
         contentView.addSubview(addToCalendarButton)
 
         addToCalendarLabel.text = ClientStrings.ClassDetail.addToCalendarButton
-        addToCalendarLabel.font = ._8SFLight
+        addToCalendarLabel.font = ._12MontserratBold
         addToCalendarLabel.textAlignment = .center
         addToCalendarLabel.textColor = .primaryBlack
         addToCalendarLabel.sizeToFit()

--- a/Uplift/Views/ClassList/CalendarCell.swift
+++ b/Uplift/Views/ClassList/CalendarCell.swift
@@ -17,8 +17,8 @@ class CalendarCell: UICollectionViewCell {
 
     override func prepareForReuse() {
         dateLabelCircle.isHidden = true
-        dateLabel.textColor = .fitnessBlack
-        dayOfWeekLabel.textColor = .fitnessBlack
+        dateLabel.textColor = .primaryBlack
+        dayOfWeekLabel.textColor = .gray04
     }
 
     override init(frame: CGRect) {
@@ -59,20 +59,20 @@ class CalendarCell: UICollectionViewCell {
 
     // MARK: - Private helpers
     private func setupViews() {
-        dateLabelCircle.backgroundColor = .fitnessBlack
+        dateLabelCircle.backgroundColor = .primaryBlack
         dateLabelCircle.isHidden = true
         dateLabelCircle.layer.cornerRadius = 12
         addSubview(dateLabelCircle)
 
-        dateLabel.font = ._12MontserratRegular
+        dateLabel.font = ._12LatoRegular
         dateLabel.textAlignment = .center
-        dateLabel.textColor = .fitnessBlack
+        dateLabel.textColor = .primaryBlack
         dateLabel.sizeToFit()
         addSubview(dateLabel)
 
-        dayOfWeekLabel.font = ._12MontserratRegular
+        dayOfWeekLabel.font = ._12LatoRegular
         dayOfWeekLabel.textAlignment = .center
-        dayOfWeekLabel.textColor = .fitnessDarkGrey
+        dayOfWeekLabel.textColor = .gray04
         dayOfWeekLabel.sizeToFit()
         addSubview(dayOfWeekLabel)
     }

--- a/Uplift/Views/ClassList/CalendarCell.swift
+++ b/Uplift/Views/ClassList/CalendarCell.swift
@@ -17,7 +17,7 @@ class CalendarCell: UICollectionViewCell {
 
     override func prepareForReuse() {
         dateLabelCircle.isHidden = true
-        dateLabel.textColor = .primaryBlack
+        dateLabel.textColor = .gray04
         dayOfWeekLabel.textColor = .gray04
     }
 
@@ -59,18 +59,18 @@ class CalendarCell: UICollectionViewCell {
 
     // MARK: - Private helpers
     private func setupViews() {
-        dateLabelCircle.backgroundColor = .primaryBlack
+        dateLabelCircle.backgroundColor = .primaryYellow
         dateLabelCircle.isHidden = true
         dateLabelCircle.layer.cornerRadius = 12
         addSubview(dateLabelCircle)
 
-        dateLabel.font = ._12LatoRegular
+        dateLabel.font = ._12MontserratMedium
         dateLabel.textAlignment = .center
-        dateLabel.textColor = .primaryBlack
+        dateLabel.textColor = .gray04
         dateLabel.sizeToFit()
         addSubview(dateLabel)
 
-        dayOfWeekLabel.font = ._12LatoRegular
+        dayOfWeekLabel.font = ._12MontserratMedium
         dayOfWeekLabel.textAlignment = .center
         dayOfWeekLabel.textColor = .gray04
         dayOfWeekLabel.sizeToFit()

--- a/Uplift/Views/ClassList/ClassListHeaderView.swift
+++ b/Uplift/Views/ClassList/ClassListHeaderView.swift
@@ -27,8 +27,8 @@ class ClassListHeaderView: UICollectionReusableView {
 
     // MARK: - CONSTRAINTS
     private func setupViews() {
-        titleLabel.font = ._14MontserratSemiBold
-        titleLabel.textColor = .fitnessDarkGrey
+        titleLabel.font = ._16MontserratBold
+        titleLabel.textColor = .primaryBlack
         titleLabel.textAlignment = .center
         addSubview(titleLabel)
     }

--- a/Uplift/Views/Empty States/NoClassesEmptyStateView.swift
+++ b/Uplift/Views/Empty States/NoClassesEmptyStateView.swift
@@ -38,7 +38,7 @@ class NoClassesEmptyStateView: UIView {
     private func setupConstraints() {
 
         emptyStateImageView.snp.makeConstraints { make in
-            make.top.equalToSuperview().offset(128)
+            make.bottom.equalTo(emptyStateTitleLabel.snp.top).offset(-24)
             make.width.height.equalTo(80)
             make.centerX.equalToSuperview()
         }

--- a/Uplift/Views/Empty States/NoClassesEmptyStateView.swift
+++ b/Uplift/Views/Empty States/NoClassesEmptyStateView.swift
@@ -22,33 +22,39 @@ class NoClassesEmptyStateView: UIView {
 
         emptyStateTitleLabel = UILabel()
         emptyStateTitleLabel.text = ClientStrings.Calendar.noClassesTodayLabel
-        emptyStateTitleLabel.font = ._20MontserratBold
-        emptyStateTitleLabel.textColor = .fitnessBlack
+        emptyStateTitleLabel.font = ._24MontserratBold
+        emptyStateTitleLabel.textColor = .primaryBlack
         addSubview(emptyStateTitleLabel)
 
         emptyStateDescriptionLabel = UILabel()
         emptyStateDescriptionLabel.text = ClientStrings.Calendar.noClassesTodayDescription
         emptyStateDescriptionLabel.font = ._14MontserratRegular
-        emptyStateDescriptionLabel.textColor = .fitnessBlack
+        emptyStateDescriptionLabel.textColor = .primaryBlack
         addSubview(emptyStateDescriptionLabel)
 
+        setupConstraints()
+    }
+
+    private func setupConstraints() {
+
+        emptyStateImageView.snp.makeConstraints { make in
+            make.top.equalToSuperview().offset(128)
+            make.width.height.equalTo(80)
+            make.centerX.equalToSuperview()
+        }
+
         emptyStateTitleLabel.snp.makeConstraints { make in
-            make.center.equalToSuperview()
+            make.centerX.equalToSuperview()
             make.width.lessThanOrEqualToSuperview()
+            make.top.equalTo(emptyStateImageView.snp.bottom).offset(24)
             make.height.equalTo(emptyStateTitleLabel.intrinsicContentSize.height)
         }
 
-        emptyStateImageView.snp.makeConstraints { make in
-            make.bottom.equalTo(emptyStateTitleLabel.snp.top).offset(-24)
-            make.width.equalTo(86.0)
-            make.height.equalTo(71.0)
-            make.centerX.equalToSuperview()
-        }
-
         emptyStateDescriptionLabel.snp.makeConstraints { make in
-            make.top.equalTo(emptyStateTitleLabel.snp.bottom).offset(8)
             make.centerX.equalToSuperview()
             make.width.lessThanOrEqualToSuperview()
+            make.top.equalTo(emptyStateTitleLabel.snp.bottom).offset(8)
+            make.height.equalTo(emptyStateTitleLabel.intrinsicContentSize.height)
         }
 
     }

--- a/Uplift/Views/Empty States/NoFavoritesEmptyStateView.swift
+++ b/Uplift/Views/Empty States/NoFavoritesEmptyStateView.swift
@@ -24,7 +24,7 @@ class NoFavoritesEmptyStateView: UIView {
         emptyStateTitleLabel = UILabel()
         emptyStateTitleLabel.text = ClientStrings.Favorites.noFavoritesText
         emptyStateTitleLabel.font = ._20MontserratBold
-        emptyStateTitleLabel.textColor = .fitnessBlack
+        emptyStateTitleLabel.textColor = .primaryBlack
         emptyStateTitleLabel.textAlignment = .center
         emptyStateTitleLabel.numberOfLines = 2
         addSubview(emptyStateTitleLabel)
@@ -38,13 +38,14 @@ class NoFavoritesEmptyStateView: UIView {
         findClassesButton.setTitle(ClientStrings.Favorites.browseClasses, for: .normal)
         findClassesButton.addTarget(self, action: #selector(findClasses), for: .touchUpInside)
         findClassesButton.titleLabel?.font = ._14MontserratBold
-        findClassesButton.setTitleColor(UIColor.fitnessBlack, for: .normal)
+        findClassesButton.setTitleColor(UIColor.primaryBlack, for: .normal)
 
-        findClassesButton.backgroundColor = .fitnessYellow
+        findClassesButton.backgroundColor = .primaryYellow
         findClassesButton.layer.cornerRadius = 32
-        findClassesButton.layer.shadowOffset = CGSize(width: 0, height: 4)
         findClassesButton.layer.shadowColor = UIColor.buttonShadow.cgColor
-        findClassesButton.layer.shadowOpacity = 0.5
+        findClassesButton.layer.shadowOffset = CGSize(width: 0, height: 2)
+        findClassesButton.layer.shadowRadius = 4.0
+        findClassesButton.layer.shadowOpacity = 1.0
         addSubview(findClassesButton)
 
         setupConstraints()

--- a/Uplift/Views/Empty States/NoResultsEmptyStateView.swift
+++ b/Uplift/Views/Empty States/NoResultsEmptyStateView.swift
@@ -8,18 +8,17 @@
 
 import UIKit
 
-
 class NoResultsEmptyStateView: UIView {
-    
+
     // MARK: - INITIALIZATION
     var emptyStateImage: UIImageView!
-    
+
     var emptyStateMessageLabel: UILabel!
     var emptyStateTitleLabel: UILabel!
-    
+
     override init(frame: CGRect) {
         super.init(frame: frame)
-        
+
         // IMAGE
         emptyStateImage = UIImageView(image: UIImage(named: "handgrip"))
         addSubview(emptyStateImage)
@@ -27,16 +26,16 @@ class NoResultsEmptyStateView: UIView {
         // TITLE
         emptyStateTitleLabel = UILabel()
         emptyStateTitleLabel.text = ClientStrings.Filter.noResultsLabel
-        emptyStateTitleLabel.font = ._20MontserratBold
-        emptyStateTitleLabel.textColor = .fitnessBlack
+        emptyStateTitleLabel.font = ._24MontserratBold
+        emptyStateTitleLabel.textColor = .primaryBlack
         emptyStateTitleLabel.textAlignment = .center
         addSubview(emptyStateTitleLabel)
-        
+
         // MESSAGE
         emptyStateMessageLabel = UILabel()
         emptyStateMessageLabel.text = ClientStrings.Filter.noResultsDescription
         emptyStateMessageLabel.font = ._14MontserratRegular
-        emptyStateMessageLabel.textColor = .fitnessBlack
+        emptyStateMessageLabel.textColor = .primaryBlack
         emptyStateMessageLabel.textAlignment = .center
         addSubview(emptyStateMessageLabel)
         
@@ -46,7 +45,7 @@ class NoResultsEmptyStateView: UIView {
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     // MARK: - CONSTRAINTS
     func setupConstraints() {
         emptyStateImage.snp.makeConstraints { make in
@@ -54,14 +53,14 @@ class NoResultsEmptyStateView: UIView {
             make.width.height.equalTo(80)
             make.centerX.equalToSuperview()
         }
-    
+
         emptyStateTitleLabel.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
             make.width.lessThanOrEqualToSuperview()
             make.top.equalTo(emptyStateImage.snp.bottom).offset(24)
             make.height.equalTo(emptyStateTitleLabel.intrinsicContentSize.height)
         }
-        
+
         emptyStateMessageLabel.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
             make.width.lessThanOrEqualToSuperview()

--- a/Uplift/Views/Empty States/NoResultsEmptyStateView.swift
+++ b/Uplift/Views/Empty States/NoResultsEmptyStateView.swift
@@ -22,7 +22,7 @@ class NoResultsEmptyStateView: UIView {
         // IMAGE
         emptyStateImage = UIImageView(image: UIImage(named: "handgrip"))
         addSubview(emptyStateImage)
-        
+
         // TITLE
         emptyStateTitleLabel = UILabel()
         emptyStateTitleLabel.text = ClientStrings.Filter.noResultsLabel
@@ -48,17 +48,17 @@ class NoResultsEmptyStateView: UIView {
 
     // MARK: - CONSTRAINTS
     func setupConstraints() {
-        emptyStateImage.snp.makeConstraints { make in
-            make.top.equalToSuperview().offset(128)
-            make.width.height.equalTo(80)
-            make.centerX.equalToSuperview()
-        }
-
         emptyStateTitleLabel.snp.makeConstraints { make in
             make.centerX.equalToSuperview()
             make.width.lessThanOrEqualToSuperview()
-            make.top.equalTo(emptyStateImage.snp.bottom).offset(24)
+            make.top.equalToSuperview().offset(197)
             make.height.equalTo(emptyStateTitleLabel.intrinsicContentSize.height)
+        }
+
+        emptyStateImage.snp.makeConstraints { make in
+            make.bottom.equalTo(emptyStateTitleLabel.snp.top).offset(-24)
+            make.width.height.equalTo(80)
+            make.centerX.equalToSuperview()
         }
 
         emptyStateMessageLabel.snp.makeConstraints { make in

--- a/Uplift/Views/Footers/DropdownFooterView.swift
+++ b/Uplift/Views/Footers/DropdownFooterView.swift
@@ -22,7 +22,7 @@ class DropdownFooterView: UITableViewHeaderFooterView {
         showHideLabel = UILabel()
         showHideLabel.font = ._12MontserratMedium
         showHideLabel.sizeToFit()
-        showHideLabel.textColor = UIColor(red: 165/255, green: 165/255, blue: 165/255, alpha: 1.0)
+        showHideLabel.textColor = .gray02
         contentView.addSubview(showHideLabel)
     }
 

--- a/Uplift/Views/GymDetail/GymDetailFacilitiesCell.swift
+++ b/Uplift/Views/GymDetail/GymDetailFacilitiesCell.swift
@@ -43,7 +43,7 @@ class GymDetailFacilitiesCell: UICollectionViewCell {
     func setupViews() {
         facilitiesLabel.font = ._16MontserratBold
         facilitiesLabel.textAlignment = .center
-        facilitiesLabel.textColor = .fitnessLightBlack
+        facilitiesLabel.textColor = .primaryBlack
         facilitiesLabel.text = ClientStrings.GymDetail.facilitiesSection
         contentView.addSubview(facilitiesLabel)
 
@@ -59,7 +59,7 @@ class GymDetailFacilitiesCell: UICollectionViewCell {
         gymFacilitiesTableView.dataSource = self
         contentView.addSubview(gymFacilitiesTableView)
 
-        dividerView.backgroundColor = .fitnessMutedGreen
+        dividerView.backgroundColor = .gray01
         contentView.addSubview(dividerView)
     }
 

--- a/Uplift/Views/GymDetail/GymDetailHeaderView.swift
+++ b/Uplift/Views/GymDetail/GymDetailHeaderView.swift
@@ -43,7 +43,7 @@ class GymDetailHeaderView: UICollectionReusableView {
         closedLabel.font = ._16MontserratSemiBold
         closedLabel.textColor = .white
         closedLabel.textAlignment = .center
-        closedLabel.backgroundColor = .fitnessBlack
+        closedLabel.backgroundColor = .primaryBlack
         closedLabel.text = ClientStrings.GymDetail.closedLabel
 
         nameLabel.font = ._36MontserratBold

--- a/Uplift/Views/GymDetail/GymDetailHeaderView.swift
+++ b/Uplift/Views/GymDetail/GymDetailHeaderView.swift
@@ -40,8 +40,8 @@ class GymDetailHeaderView: UICollectionReusableView {
         imageView.clipsToBounds = true
         addSubview(imageView)
 
-        closedLabel.font = ._16MontserratSemiBold
-        closedLabel.textColor = .white
+        closedLabel.font = ._16MontserratMedium
+        closedLabel.textColor = .primaryWhite
         closedLabel.textAlignment = .center
         closedLabel.backgroundColor = .primaryBlack
         closedLabel.text = ClientStrings.GymDetail.closedLabel

--- a/Uplift/Views/GymDetail/GymDetailHoursCell.swift
+++ b/Uplift/Views/GymDetail/GymDetailHoursCell.swift
@@ -74,7 +74,7 @@ class GymDetailHoursCell: UICollectionViewCell {
     // MARK: - Private helpers
     private func setupViews() {
         hoursTitleLabel.font = ._16MontserratBold
-        hoursTitleLabel.textColor = .fitnessLightBlack
+        hoursTitleLabel.textColor = .primaryBlack
         hoursTitleLabel.textAlignment = .center
         hoursTitleLabel.text = ClientStrings.GymDetail.hoursLabel
         contentView.addSubview(hoursTitleLabel)
@@ -92,7 +92,7 @@ class GymDetailHoursCell: UICollectionViewCell {
         hoursTableView.dataSource = self
         contentView.addSubview(hoursTableView)
 
-        dividerView.backgroundColor = .fitnessMutedGreen
+        dividerView.backgroundColor = .gray01
         contentView.addSubview(dividerView)
     }
 

--- a/Uplift/Views/GymDetail/GymDetailPopularTimesCell.swift
+++ b/Uplift/Views/GymDetail/GymDetailPopularTimesCell.swift
@@ -49,11 +49,11 @@ class GymDetailPopularTimesCell: UICollectionViewCell {
     private func setupViews() {
         popularTimesLabel.text = ClientStrings.GymDetail.popularHoursSection
         popularTimesLabel.font = ._16MontserratBold
-        popularTimesLabel.textColor = .fitnessLightBlack
+        popularTimesLabel.textColor = .primaryBlack
         popularTimesLabel.textAlignment = .center
         contentView.addSubview(popularTimesLabel)
 
-        dividerView.backgroundColor = .fitnessMutedGreen
+        dividerView.backgroundColor = .gray01
         contentView.addSubview(dividerView)
     }
 

--- a/Uplift/Views/GymDetail/GymDetailTodaysClassesCell.swift
+++ b/Uplift/Views/GymDetail/GymDetailTodaysClassesCell.swift
@@ -52,13 +52,13 @@ class GymDetailTodaysClassesCell: UICollectionViewCell {
     // MARK: - Private helpers
     private func setupViews() {
         todaysClassesLabel.font = ._16MontserratBold
-        todaysClassesLabel.textColor = .fitnessLightBlack
+        todaysClassesLabel.textColor = .primaryBlack
         todaysClassesLabel.text = ClientStrings.GymDetail.todaysClassesSection
         todaysClassesLabel.textAlignment = .center
         contentView.addSubview(todaysClassesLabel)
 
         noMoreClassesLabel.font = UIFont._14MontserratLight
-        noMoreClassesLabel.textColor = .fitnessLightBlack
+        noMoreClassesLabel.textColor = .primaryBlack
         noMoreClassesLabel.text = ClientStrings.GymDetail.noMoreClasses
         noMoreClassesLabel.numberOfLines = 0
         noMoreClassesLabel.textAlignment = .center

--- a/Uplift/Views/Headers/DropdownHeaderView.swift
+++ b/Uplift/Views/Headers/DropdownHeaderView.swift
@@ -34,7 +34,7 @@ class DropdownHeaderView: UITableViewHeaderFooterView {
         layer.backgroundColor = UIColor.white.cgColor
 
         titleLabel = UILabel()
-        titleLabel.font = ._12LatoBlack
+        titleLabel.font = ._12MontserratBold
         titleLabel.textColor = .gray04
         titleLabel.sizeToFit()
         contentView.addSubview(titleLabel)
@@ -46,7 +46,7 @@ class DropdownHeaderView: UITableViewHeaderFooterView {
         selectedFiltersLabel = UILabel()
         selectedFiltersLabel.textAlignment = .right
         selectedFiltersLabel.font = UIFont._14MontserratRegular
-        selectedFiltersLabel.textColor = UIColor.gray04
+        selectedFiltersLabel.textColor = .primaryBlack
         selectedFiltersLabel.adjustsFontSizeToFitWidth = false
         selectedFiltersLabel.lineBreakMode = NSLineBreakMode.byTruncatingTail
         contentView.addSubview(selectedFiltersLabel)

--- a/Uplift/Views/Headers/DropdownHeaderView.swift
+++ b/Uplift/Views/Headers/DropdownHeaderView.swift
@@ -20,7 +20,7 @@ class DropdownHeaderView: UITableViewHeaderFooterView {
     
     var filtersApplied: Bool = false {
         didSet {
-            self.filtersAppliedCircle.layer.backgroundColor = filtersApplied ? UIColor.fitnessYellow.cgColor : UIColor.fitnessWhite.cgColor
+            self.filtersAppliedCircle.layer.backgroundColor = filtersApplied ? UIColor.primaryYellow.cgColor : UIColor.primaryWhite.cgColor
         }
     }
     var selectedFilters: [String] = [] {
@@ -35,7 +35,7 @@ class DropdownHeaderView: UITableViewHeaderFooterView {
 
         titleLabel = UILabel()
         titleLabel.font = ._12LatoBlack
-        titleLabel.textColor = .fitnessDarkGrey
+        titleLabel.textColor = .gray04
         titleLabel.sizeToFit()
         contentView.addSubview(titleLabel)
         
@@ -46,7 +46,7 @@ class DropdownHeaderView: UITableViewHeaderFooterView {
         selectedFiltersLabel = UILabel()
         selectedFiltersLabel.textAlignment = .right
         selectedFiltersLabel.font = UIFont._14MontserratRegular
-        selectedFiltersLabel.textColor = UIColor.fitnessDarkGrey
+        selectedFiltersLabel.textColor = UIColor.gray04
         selectedFiltersLabel.adjustsFontSizeToFitWidth = false
         selectedFiltersLabel.lineBreakMode = NSLineBreakMode.byTruncatingTail
         contentView.addSubview(selectedFiltersLabel)

--- a/Uplift/Views/Headers/FacilityHoursHeaderView.swift
+++ b/Uplift/Views/Headers/FacilityHoursHeaderView.swift
@@ -42,7 +42,7 @@ class FacilityHoursHeaderView: UITableViewHeaderFooterView {
         
         statusLabel = UILabel()
         statusLabel.font = ._12MontserratMedium
-        statusLabel.textColor = .openGreen
+        statusLabel.textColor = .accentOpen
         statusLabel.sizeToFit()
         statusLabel.textAlignment = .left
         contentView.addSubview(statusLabel)

--- a/Uplift/Views/Headers/FacilityHoursHeaderView.swift
+++ b/Uplift/Views/Headers/FacilityHoursHeaderView.swift
@@ -25,7 +25,7 @@ class FacilityHoursHeaderView: UITableViewHeaderFooterView {
         
         facilityNameLabel = UILabel()
         facilityNameLabel.font = ._16MontserratMedium
-        facilityNameLabel.textColor = .fitnessBlack
+        facilityNameLabel.textColor = .primaryBlack
         facilityNameLabel.sizeToFit()
         facilityNameLabel.textAlignment = .left
         facilityNameLabel.text = ""
@@ -42,14 +42,14 @@ class FacilityHoursHeaderView: UITableViewHeaderFooterView {
         
         statusLabel = UILabel()
         statusLabel.font = ._12MontserratMedium
-        statusLabel.textColor = .fitnessGreen
+        statusLabel.textColor = .openGreen
         statusLabel.sizeToFit()
         statusLabel.textAlignment = .left
         contentView.addSubview(statusLabel)
         
         todayTimeLabel = UILabel()
         todayTimeLabel.font = ._12MontserratRegular
-        todayTimeLabel.textColor = .fitnessBlack
+        todayTimeLabel.textColor = .primaryBlack
         todayTimeLabel.sizeToFit()
         todayTimeLabel.textAlignment = .left
         contentView.addSubview(todayTimeLabel)

--- a/Uplift/Views/Headers/FavoritesHeaderView.swift
+++ b/Uplift/Views/Headers/FavoritesHeaderView.swift
@@ -25,7 +25,7 @@ class FavoritesHeaderView: UICollectionReusableView {
         // QUOTE LABEL
         quoteLabel = UILabel()
         quoteLabel.font = ._32Bebas
-        quoteLabel.textColor = .fitnessBlack
+        quoteLabel.textColor = .primaryBlack
         quoteLabel.textAlignment = .center
         quoteLabel.lineBreakMode = .byWordWrapping
         quoteLabel.numberOfLines = 0
@@ -34,8 +34,8 @@ class FavoritesHeaderView: UICollectionReusableView {
 
         // SESSIONS LABEL
         nextSessionsLabel = UILabel()
-        nextSessionsLabel.font = ._12LatoBlack
-        nextSessionsLabel.textColor = .fitnessDarkGrey
+        nextSessionsLabel.font = ._16MontserratBold
+        nextSessionsLabel.textColor = .primaryBlack
         nextSessionsLabel.textAlignment = .center
         nextSessionsLabel.text = ClientStrings.Favorites.comingUpNextLabel
         addSubview(nextSessionsLabel)
@@ -56,7 +56,7 @@ class FavoritesHeaderView: UICollectionReusableView {
         }
 
         nextSessionsLabel.snp.updateConstraints { make in
-            make.top.equalTo(quoteLabel.snp.bottom).offset(62)
+            make.top.equalTo(quoteLabel.snp.bottom).offset(32)
             make.centerX.equalToSuperview()
             make.width.lessThanOrEqualToSuperview().offset(40)
             make.height.equalTo(18)

--- a/Uplift/Views/Headers/GymHoursHeaderView.swift
+++ b/Uplift/Views/Headers/GymHoursHeaderView.swift
@@ -23,7 +23,7 @@ class GymHoursHeaderView: UITableViewHeaderFooterView {
 
         hoursLabel = UILabel()
         hoursLabel.font = ._16MontserratMedium
-        hoursLabel.textColor = .fitnessBlack
+        hoursLabel.textColor = .primaryBlack
         hoursLabel.sizeToFit()
         hoursLabel.textAlignment = .center
         hoursLabel.text = "6: 00 AM - 9: 00 PM"

--- a/Uplift/Views/Headers/HomeScreenHeaderView.swift
+++ b/Uplift/Views/Headers/HomeScreenHeaderView.swift
@@ -23,7 +23,7 @@ class HomeScreenHeaderView: UIView {
         // WELCOME MESSAGE
         welcomeMessage = UILabel()
         welcomeMessage.font = ._24MontserratBold
-        welcomeMessage.textColor = .fitnessBlack
+        welcomeMessage.textColor = .primaryBlack
         welcomeMessage.lineBreakMode = .byWordWrapping
         welcomeMessage.numberOfLines = 0
         welcomeMessage.text = getGreeting()

--- a/Uplift/Views/Headers/HomeSectionHeaderView.swift
+++ b/Uplift/Views/Headers/HomeSectionHeaderView.swift
@@ -31,12 +31,12 @@ class HomeSectionHeaderView: UICollectionReusableView {
 
         titleLabel = UILabel()
         titleLabel.font = ._14MontserratBold
-        titleLabel.textColor = .fitnessDarkGrey
+        titleLabel.textColor = .gray04
         titleLabel.text = ""
         addSubview(titleLabel)
 
         navigationButton = UIButton()
-        navigationButton.setTitleColor(.fitnessDarkGrey, for: .normal)
+        navigationButton.setTitleColor(.gray04, for: .normal)
         navigationButton.contentHorizontalAlignment = .right
         navigationButton.titleLabel?.font = ._14LatoBlack
         navigationButton.addTarget(self, action: #selector(viewAll), for: .touchUpInside)

--- a/Uplift/Views/Histogram.swift
+++ b/Uplift/Views/Histogram.swift
@@ -56,7 +56,7 @@ class Histogram: UIView {
 
         // AXIS
         bottomAxis = UIView()
-        bottomAxis.backgroundColor = .fitnessMediumGrey
+        bottomAxis.backgroundColor = .gray01
         addSubview(bottomAxis)
 
         bottomAxisTicks = []
@@ -65,7 +65,7 @@ class Histogram: UIView {
 
         for _ in openHour..<(closeHour - 1) {
             let tick = UIView()
-            tick.backgroundColor = .fitnessMediumGrey
+            tick.backgroundColor = .gray01
             addSubview(tick)
             bottomAxisTicks.append(tick)
         }
@@ -74,7 +74,8 @@ class Histogram: UIView {
         bars = []
         for _ in openHour..<closeHour {
             let bar = UIView()
-            bar.backgroundColor = .primaryYellow
+            bar.backgroundColor = .primaryLightYellow
+            bar.layer.cornerRadius = 2.0
             addSubview(bar)
             bars.append(bar)
 
@@ -93,24 +94,24 @@ class Histogram: UIView {
         }
 
         if selectedIndex < bars.count {
-            bars[selectedIndex].backgroundColor = .fitnessSelectedYellow
+            bars[selectedIndex].backgroundColor = .primaryYellow
         }
 
         // SELECTED INFO
         selectedLine = UIView()
-        selectedLine.backgroundColor = .fitnessMediumGrey
+        selectedLine.backgroundColor = .gray03
         addSubview(selectedLine)
 
         selectedTime = UILabel()
         selectedTime.textColor = .gray04
-        selectedTime.font = ._12LatoBold
+        selectedTime.font = ._12MontserratBold
         selectedTime.textAlignment = .right
-        selectedTime.text = todaysHours.openTime.addingTimeInterval( Double(selectedIndex) * secondsPerHour ).getStringOfDatetime(format: "ha :")
+        selectedTime.text = todaysHours.openTime.addingTimeInterval( Double(selectedIndex) * secondsPerHour ).getStringOfDatetime(format: "ha")
         addSubview(selectedTime)
 
         selectedTimeDescriptor = UILabel()
         selectedTimeDescriptor.textColor = .gray04
-        selectedTimeDescriptor.font = ._12LatoRegular
+        selectedTimeDescriptor.font = ._12MontserratMedium
         selectedTimeDescriptor.textAlignment = .left
         selectedTimeDescriptor.text = timeDescriptorText
         selectedTimeDescriptor.sizeToFit()
@@ -129,7 +130,7 @@ class Histogram: UIView {
         bottomAxis.snp.makeConstraints { make in
             make.leading.trailing.equalToSuperview()
             make.bottom.equalToSuperview().offset(-1)
-            make.height.equalTo(2)
+            make.height.equalTo(1)
         }
 
         let tickSpacing = (Int(frame.width) - bottomAxisTicks.count * 2 - 4) / (bottomAxisTicks.count + 1)
@@ -137,7 +138,7 @@ class Histogram: UIView {
 
         (0..<bottomAxisTicks.count).forEach { i in
             let tick = bottomAxisTicks[i]
-            let tickWidth: CGFloat = 2
+            let tickWidth: CGFloat = 1
             let tickHeight: CGFloat = 3
 
             tick.snp.makeConstraints { make in
@@ -183,7 +184,7 @@ class Histogram: UIView {
             selectedLine.snp.remakeConstraints { make in
                 make.centerX.equalTo(bars[selectedIndex].snp.centerX)
                 make.bottom.equalTo(bars[selectedIndex].snp.top)
-                make.width.equalTo(2)
+                make.width.equalTo(1)
                 make.top.equalToSuperview().offset(26)
             }
         }
@@ -215,19 +216,17 @@ class Histogram: UIView {
             // Only update if user selected a different bar
             if selectedIndex != indexSelected {
                 if selectedIndex < bars.count {
-                    bars[selectedIndex].backgroundColor = .primaryYellow
+                    bars[selectedIndex].backgroundColor = .primaryLightYellow
                 }
 
                 selectedIndex = indexSelected
 
-                selectedBar.backgroundColor = .fitnessSelectedYellow
+                selectedBar.backgroundColor = .primaryYellow
 
                 selectedTimeDescriptor.text = timeDescriptorText
                 selectedTimeDescriptor.sizeToFit()
 
-                selectedTime.text = hours.openTime.addingTimeInterval( Double(selectedIndex) * secondsPerHour ).getStringOfDatetime(format: "ha :")
-
-                selectedTime.text = hours.openTime.addingTimeInterval( Double(selectedIndex) * secondsPerHour ).getStringOfDatetime(format: "ha :")
+                selectedTime.text = hours.openTime.addingTimeInterval( Double(selectedIndex) * secondsPerHour ).getStringOfDatetime(format: "ha")
 
                 setupSelectedConstraints()
             }

--- a/Uplift/Views/Histogram.swift
+++ b/Uplift/Views/Histogram.swift
@@ -56,7 +56,7 @@ class Histogram: UIView {
 
         // AXIS
         bottomAxis = UIView()
-        bottomAxis.backgroundColor = .fitnessLightGrey
+        bottomAxis.backgroundColor = .fitnessMediumGrey
         addSubview(bottomAxis)
 
         bottomAxisTicks = []
@@ -65,7 +65,7 @@ class Histogram: UIView {
 
         for _ in openHour..<(closeHour - 1) {
             let tick = UIView()
-            tick.backgroundColor = .fitnessLightGrey
+            tick.backgroundColor = .fitnessMediumGrey
             addSubview(tick)
             bottomAxisTicks.append(tick)
         }
@@ -74,7 +74,7 @@ class Histogram: UIView {
         bars = []
         for _ in openHour..<closeHour {
             let bar = UIView()
-            bar.backgroundColor = .fitnessYellow
+            bar.backgroundColor = .primaryYellow
             addSubview(bar)
             bars.append(bar)
 
@@ -93,23 +93,27 @@ class Histogram: UIView {
         }
 
         if selectedIndex < bars.count {
-            bars[selectedIndex].backgroundColor = UIColor(red: 216/255, green: 200/255, blue: 0, alpha: 1.0)
+            let gradient = CAGradientLayer()
+            gradient.frame = bars[selectedIndex].bounds
+            gradient.colors = [UIColor.primaryYellow.cgColor, UIColor.fitnessSelectedYellow.cgColor]
+//            bars[selectedIndex].backgroundColor = .primaryYellow
+            bars[selectedIndex].layer.insertSublayer(gradient, at: 0)
         }
 
         // SELECTED INFO
         selectedLine = UIView()
-        selectedLine.backgroundColor = .fitnessLightGrey
+        selectedLine.backgroundColor = .fitnessMediumGrey
         addSubview(selectedLine)
 
         selectedTime = UILabel()
-        selectedTime.textColor = .fitnessDarkGrey
+        selectedTime.textColor = .gray04
         selectedTime.font = ._12LatoBold
         selectedTime.textAlignment = .right
         selectedTime.text = todaysHours.openTime.addingTimeInterval( Double(selectedIndex) * secondsPerHour ).getStringOfDatetime(format: "ha :")
         addSubview(selectedTime)
 
         selectedTimeDescriptor = UILabel()
-        selectedTimeDescriptor.textColor = .fitnessDarkGrey
+        selectedTimeDescriptor.textColor = .gray04
         selectedTimeDescriptor.font = ._12LatoRegular
         selectedTimeDescriptor.textAlignment = .left
         selectedTimeDescriptor.text = timeDescriptorText
@@ -208,22 +212,28 @@ class Histogram: UIView {
         }
     }
 
-    @objc func selectBar( sender: UITapGestureRecognizer) {
+    @objc func selectBar(sender: UITapGestureRecognizer) {
         let selectedBar = sender.view!
 
         if let indexSelected = bars.firstIndex(of: selectedBar) {
             // Only update if user selected a different bar
             if selectedIndex != indexSelected {
                 if selectedIndex < bars.count {
-                    bars[selectedIndex].backgroundColor = .fitnessYellow
+                    bars[selectedIndex].layer.sublayers?.removeLast()
+//                    bars[selectedIndex].backgroundColor = .primaryYellow
                 }
 
                 selectedIndex = indexSelected
-                selectedBar.backgroundColor = .fitnessSelectedYellow
-        selectedTimeDescriptor.text = timeDescriptorText
-        selectedTimeDescriptor.sizeToFit()
 
-        selectedTime.text = hours.openTime.addingTimeInterval( Double(selectedIndex) * secondsPerHour ).getStringOfDatetime(format: "ha :")
+                let gradient = CAGradientLayer()
+                gradient.frame = selectedBar.bounds
+                gradient.colors = [UIColor.primaryYellow.cgColor, UIColor.fitnessSelectedYellow.cgColor]
+                selectedBar.layer.insertSublayer(gradient, at: 0)
+
+                selectedTimeDescriptor.text = timeDescriptorText
+                selectedTimeDescriptor.sizeToFit()
+
+                selectedTime.text = hours.openTime.addingTimeInterval( Double(selectedIndex) * secondsPerHour ).getStringOfDatetime(format: "ha :")
 
                 selectedTime.text = hours.openTime.addingTimeInterval( Double(selectedIndex) * secondsPerHour ).getStringOfDatetime(format: "ha :")
 

--- a/Uplift/Views/Histogram.swift
+++ b/Uplift/Views/Histogram.swift
@@ -93,11 +93,7 @@ class Histogram: UIView {
         }
 
         if selectedIndex < bars.count {
-            let gradient = CAGradientLayer()
-            gradient.frame = bars[selectedIndex].bounds
-            gradient.colors = [UIColor.primaryYellow.cgColor, UIColor.fitnessSelectedYellow.cgColor]
-//            bars[selectedIndex].backgroundColor = .primaryYellow
-            bars[selectedIndex].layer.insertSublayer(gradient, at: 0)
+            bars[selectedIndex].backgroundColor = .fitnessSelectedYellow
         }
 
         // SELECTED INFO
@@ -219,16 +215,12 @@ class Histogram: UIView {
             // Only update if user selected a different bar
             if selectedIndex != indexSelected {
                 if selectedIndex < bars.count {
-                    bars[selectedIndex].layer.sublayers?.removeLast()
-//                    bars[selectedIndex].backgroundColor = .primaryYellow
+                    bars[selectedIndex].backgroundColor = .primaryYellow
                 }
 
                 selectedIndex = indexSelected
 
-                let gradient = CAGradientLayer()
-                gradient.frame = selectedBar.bounds
-                gradient.colors = [UIColor.primaryYellow.cgColor, UIColor.fitnessSelectedYellow.cgColor]
-                selectedBar.layer.insertSublayer(gradient, at: 0)
+                selectedBar.backgroundColor = .fitnessSelectedYellow
 
                 selectedTimeDescriptor.text = timeDescriptorText
                 selectedTimeDescriptor.sizeToFit()

--- a/Uplift/Views/Histogram.swift
+++ b/Uplift/Views/Histogram.swift
@@ -28,8 +28,9 @@ class Histogram: UIView {
     private let mediumThreshold = 25
     private let secondsPerHour: Double = 3600.0
     private let timeDescriptors = [ClientStrings.Histogram.businessLevel1, ClientStrings.Histogram.businessLevel2, ClientStrings.Histogram.businessLevel3]
+
     /// Returns the proper time descriptor label text
-    private var timeDescriptorText: String { 
+    private var timeDescriptorText: String {
         get {
             if data[selectedIndex + openHour] < mediumThreshold {
                 return timeDescriptors[0]
@@ -76,6 +77,7 @@ class Histogram: UIView {
             let bar = UIView()
             bar.backgroundColor = .primaryLightYellow
             bar.layer.cornerRadius = 2.0
+            bar.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
             addSubview(bar)
             bars.append(bar)
 
@@ -159,16 +161,16 @@ class Histogram: UIView {
             let bar = bars[i]
 
             bar.snp.makeConstraints { make in
-                make.bottom.equalTo(bottomAxis.snp.top)
+                make.bottom.equalTo(bottomAxis.snp.top).offset(-1)
                 if i == 0 {
-                    make.width.equalTo(tickSpacing)
+                    make.width.equalTo(tickSpacing - 2)
                     make.trailing.equalTo(bottomAxisTicks[i].snp.leading)
                 } else if i == bars.count - 1 {
-                    make.width.equalTo(tickSpacing)
+                    make.width.equalTo(tickSpacing - 2)
                     make.leading.equalTo(bottomAxisTicks[i - 1].snp.trailing)
                 } else {
-                    make.leading.equalTo(bottomAxisTicks[i - 1].snp.trailing)
-                    make.trailing.equalTo(bottomAxisTicks[i].snp.leading)
+                    make.leading.equalTo(bottomAxisTicks[i - 1].snp.trailing).offset(1)
+                    make.trailing.equalTo(bottomAxisTicks[i].snp.leading).offset(-1)
                 }
                 let height = 72 * (data[i + openHour]) / 100
                 make.height.equalTo(height)

--- a/Uplift/Views/Home/CheckInListItemCell.swift
+++ b/Uplift/Views/Home/CheckInListItemCell.swift
@@ -55,7 +55,7 @@ class CheckInListItemCell: ListItemCollectionViewCell<Habit> {
         checkInButton.addTarget(self, action: #selector(checkIn), for: .touchUpInside)
         contentView.addSubview(checkInButton)
 
-        titleLabel.textColor = .fitnessBlack
+        titleLabel.textColor = .primaryBlack
         titleLabel.font = ._16MontserratMedium
         contentView.addSubview(titleLabel)
 
@@ -63,7 +63,7 @@ class CheckInListItemCell: ListItemCollectionViewCell<Habit> {
         streakLabel.font = ._16MontserratBold
         contentView.addSubview(streakLabel)
 
-        dividerView.backgroundColor = .fitnessLightGrey
+        dividerView.backgroundColor = .gray01
         contentView.addSubview(dividerView)
     }
 
@@ -108,7 +108,7 @@ class CheckInListItemCell: ListItemCollectionViewCell<Habit> {
     
     override func prepareForReuse() {
         super.prepareForReuse()
-        titleLabel.textColor = .fitnessBlack
+        titleLabel.textColor = .primaryBlack
         checkInButton.isSelected = false
     }
     
@@ -119,7 +119,7 @@ class CheckInListItemCell: ListItemCollectionViewCell<Habit> {
 
             titleLabel.attributedText = nil
             titleLabel.text = habit.title
-            titleLabel.textColor = .fitnessBlack
+            titleLabel.textColor = .primaryBlack
         } else {
             Habit.logDate(habit: habit, date: Date())
 

--- a/Uplift/Views/Home/GymListItemCell.swift
+++ b/Uplift/Views/Home/GymListItemCell.swift
@@ -26,18 +26,16 @@ class GymListItemCell: ListItemCollectionViewCell<Gym> {
 
         // BORDER
         contentView.layer.cornerRadius = 5
-        contentView.layer.backgroundColor = UIColor.white.cgColor
-        contentView.layer.borderColor = UIColor.fitnessLightGrey.cgColor
-        contentView.layer.borderWidth = 0.5
+        contentView.layer.backgroundColor = UIColor.primaryWhite.cgColor
+        contentView.layer.borderColor = UIColor.gray01.cgColor
+        contentView.layer.borderWidth = 1.0
 
         // SHADOWING
-        contentView.layer.shadowColor = UIColor.fitnessBlack.cgColor
-        contentView.layer.shadowOffset = CGSize(width: 0.0, height: 15.0)
-        contentView.layer.shadowRadius = 5.0
-        contentView.layer.shadowOpacity = 0.1
+        contentView.layer.shadowColor = UIColor(red: 0.15, green: 0.15, blue: 0.37, alpha: 0.1).cgColor
+        contentView.layer.shadowOffset = CGSize(width: 0.0, height: 4.0)
+        contentView.layer.shadowRadius = 10.0
+        contentView.layer.shadowOpacity = 1.0
         contentView.layer.masksToBounds = false
-        let shadowFrame = contentView.frame.inset(by: UIEdgeInsets(top: 0, left: 0, bottom: 9, right: -3))
-        contentView.layer.shadowPath = UIBezierPath(roundedRect: shadowFrame, cornerRadius: 5).cgPath
 
         setupViews()
         setupConstraints()
@@ -54,18 +52,18 @@ class GymListItemCell: ListItemCollectionViewCell<Gym> {
         let changingSoon = gym.isStatusChangingSoon()
         if gym.isOpen {
             if changingSoon {
-                statusLabel.textColor = .fitnessOrange
+                statusLabel.textColor = .accentOrange
                 statusLabel.text = ClientStrings.Home.gymDetailCellOpen
             } else {
-                statusLabel.textColor = .fitnessGreen
+                statusLabel.textColor = .openGreen
                 statusLabel.text = ClientStrings.Home.gymDetailCellOpen
             }
         } else {
             if changingSoon {
-                statusLabel.textColor = .fitnessOrange
+                statusLabel.textColor = .accentOrange
                 statusLabel.text = ClientStrings.Home.gymDetailCellClosed
             } else {
-                statusLabel.textColor = .fitnessRed
+                statusLabel.textColor = .closedRed
                 statusLabel.text = ClientStrings.Home.gymDetailCellClosed
             }
         }
@@ -105,29 +103,28 @@ class GymListItemCell: ListItemCollectionViewCell<Gym> {
 
     private func setupViews() {
         // YELLOW BAR
-        colorBar.backgroundColor = .fitnessYellow
+        colorBar.backgroundColor = .primaryYellow
         colorBar.clipsToBounds = true
         colorBar.layer.cornerRadius = 5
         colorBar.layer.maskedCorners = [.layerMinXMinYCorner, .layerMinXMaxYCorner]
         contentView.addSubview(colorBar)
 
         locationNameLabel.font = ._16MontserratMedium
-        locationNameLabel.textColor = .fitnessBlack
+        locationNameLabel.textColor = .primaryBlack
         locationNameLabel.textAlignment = .left
         contentView.addSubview(locationNameLabel)
 
         statusLabel.font = ._14MontserratMedium
         contentView.addSubview(statusLabel)
 
-        hoursLabel.font = ._14MontserratMedium
-        hoursLabel.textColor = .fitnessDarkGrey
+        hoursLabel.font = ._12MontserratMedium
+        hoursLabel.textColor = .gray04
         contentView.addSubview(hoursLabel)
     }
 
     private func setupConstraints() {
         let colorBarWidth = 5
         let descriptionLabelHeight = 15
-        let hoursLabelTopPadding = 3
         let leadingPadding = 16
         let locationLabelHeight = 22
         let locationLabelVerticalInset = 12

--- a/Uplift/Views/Home/GymListItemCell.swift
+++ b/Uplift/Views/Home/GymListItemCell.swift
@@ -55,7 +55,7 @@ class GymListItemCell: ListItemCollectionViewCell<Gym> {
                 statusLabel.textColor = .accentOrange
                 statusLabel.text = ClientStrings.Home.gymDetailCellOpen
             } else {
-                statusLabel.textColor = .openGreen
+                statusLabel.textColor = .accentOpen
                 statusLabel.text = ClientStrings.Home.gymDetailCellOpen
             }
         } else {
@@ -63,7 +63,7 @@ class GymListItemCell: ListItemCollectionViewCell<Gym> {
                 statusLabel.textColor = .accentOrange
                 statusLabel.text = ClientStrings.Home.gymDetailCellClosed
             } else {
-                statusLabel.textColor = .closedRed
+                statusLabel.textColor = .accentClosed
                 statusLabel.text = ClientStrings.Home.gymDetailCellClosed
             }
         }

--- a/Uplift/Views/Home/GymListItemCell.swift
+++ b/Uplift/Views/Home/GymListItemCell.swift
@@ -114,11 +114,11 @@ class GymListItemCell: ListItemCollectionViewCell<Gym> {
         locationNameLabel.textAlignment = .left
         contentView.addSubview(locationNameLabel)
 
-        statusLabel.font = ._14MontserratMedium
+        statusLabel.font = ._12MontserratMedium
         contentView.addSubview(statusLabel)
 
         hoursLabel.font = ._12MontserratMedium
-        hoursLabel.textColor = .gray04
+        hoursLabel.textColor = .gray02
         contentView.addSubview(hoursLabel)
     }
 

--- a/Uplift/Views/Home/LookingForListCell.swift
+++ b/Uplift/Views/Home/LookingForListCell.swift
@@ -27,11 +27,9 @@ class LookingForListCell: ListCollectionViewCell<Tag, LookingForListItemCell> {
     static let minimumInterItemSpacing: CGFloat = 16
     static let minimumLineSpacing: CGFloat = 16
     static let sectionInset = UIEdgeInsets(top: 0.0, left: 16.0, bottom: 32.0, right: 16.0)
-    
-    
+
     // MARK: - Overrides
     override var config: ListConfiguration {
-        
         return ListConfiguration(
             isScrollEnabled: false,
             itemSize: CGSize(width: self.width, height: self.height),
@@ -58,7 +56,7 @@ class LookingForListCell: ListCollectionViewCell<Tag, LookingForListItemCell> {
         guard let cell = collectionView.cellForItem(at: indexPath) else { return }
         cell.zoomIn()
     }
-    
+
     override func didUnhighlightItemAt(_ collectionView: UICollectionView, indexPath: IndexPath) {
         guard let cell = collectionView.cellForItem(at: indexPath) else { return }
         cell.zoomOut()

--- a/Uplift/Views/Home/LookingForListItemCell.swift
+++ b/Uplift/Views/Home/LookingForListItemCell.swift
@@ -13,17 +13,17 @@ class LookingForListItemCell: ListItemCollectionViewCell<Tag> {
     
     // MARK: - Public static vars
     static let identifier = Identifiers.categoryCell
-    
+
     // MARK: - INITIALIZATION
     private var image: UIImageView!
     private var title: UILabel!
-    
+
     override init(frame: CGRect) {
         super.init(frame: frame)
-        
+
         layer.cornerRadius = frame.height/32
         clipsToBounds = true
-        
+
         // IMAGE
         image = UIImageView()
         contentView.addSubview(image)
@@ -31,24 +31,29 @@ class LookingForListItemCell: ListItemCollectionViewCell<Tag> {
         // TITLE
         title = UILabel()
         title.font = ._16MontserratSemiBold
-        title.textColor = .white
+        title.textColor = .primaryWhite
+        title.layer.shadowColor = UIColor.primaryBlack.cgColor
+        title.layer.shadowOffset = CGSize(width: 0, height: 4)
+        title.layer.shadowRadius = 10.0
+        title.layer.shadowOpacity = 1.0
+        title.layer.masksToBounds = false
         contentView.addSubview(title)
-        
+
         setupConstraints()
     }
-    
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     override func configure(for tag: Tag) {
         super.configure(for: tag)
-        
+
         title.text = tag.name
         let url = URL(string: tag.imageURL)
         image.kf.setImage(with: url)
     }
-    
+
     // MARK: - CONSTRAINTS
     func setupConstraints() {
         image.snp.updateConstraints { make in

--- a/Uplift/Views/Home/LookingForListItemCell.swift
+++ b/Uplift/Views/Home/LookingForListItemCell.swift
@@ -27,7 +27,7 @@ class LookingForListItemCell: ListItemCollectionViewCell<Tag> {
         // IMAGE
         image = UIImageView()
         contentView.addSubview(image)
-        
+
         // TITLE
         title = UILabel()
         title.font = ._16MontserratSemiBold
@@ -55,11 +55,10 @@ class LookingForListItemCell: ListItemCollectionViewCell<Tag> {
             make.size.equalToSuperview()
             make.center.equalToSuperview()
         }
-        
+
         title.snp.updateConstraints { make in
             make.center.equalToSuperview()
         }
     }
-    
-}
 
+}

--- a/Uplift/Views/Home/TodaysClassListItemCell.swift
+++ b/Uplift/Views/Home/TodaysClassListItemCell.swift
@@ -76,7 +76,7 @@ class TodaysClassListItemCell: ListItemCollectionViewCell<GymClassInstance> {
         imageView.contentMode = .scaleAspectFill
         contentView.addSubview(imageView)
 
-        cancelledView.backgroundColor = .closedRed
+        cancelledView.backgroundColor = .accentClosed
         cancelledView.isHidden = true
         contentView.addSubview(cancelledView)
 

--- a/Uplift/Views/Home/TodaysClassListItemCell.swift
+++ b/Uplift/Views/Home/TodaysClassListItemCell.swift
@@ -29,17 +29,15 @@ class TodaysClassListItemCell: ListItemCollectionViewCell<GymClassInstance> {
         // BORDER
         contentView.layer.cornerRadius = 5
         contentView.layer.backgroundColor = UIColor.white.cgColor
-        contentView.layer.borderColor = UIColor.fitnessLightGrey.cgColor
-        contentView.layer.borderWidth = 0.5
+        contentView.layer.borderColor = UIColor.gray01.cgColor
+        contentView.layer.borderWidth = 1.0
 
         // SHADOWING
-        contentView.layer.shadowColor = UIColor.fitnessBlack.cgColor
-        contentView.layer.shadowOffset = CGSize(width: 0.0, height: 8.0)
-        contentView.layer.shadowRadius = 3.0
-        contentView.layer.shadowOpacity = 0.1
+        contentView.layer.shadowColor = UIColor.gray01.cgColor
+        contentView.layer.shadowOffset = CGSize(width: 0.0, height: 11.0)
+        contentView.layer.shadowRadius = 7.0
+        contentView.layer.shadowOpacity = 1.0
         contentView.layer.masksToBounds = false
-        let shadowFrame = contentView.frame.inset(by: UIEdgeInsets(top: 0, left: 0, bottom: 4, right: -2))
-        contentView.layer.shadowPath = UIBezierPath(roundedRect: shadowFrame, cornerRadius: 5).cgPath
 
         setupViews()
         setupConstraints()
@@ -55,7 +53,7 @@ class TodaysClassListItemCell: ListItemCollectionViewCell<GymClassInstance> {
         if item.isCancelled {
             cancelledView.isHidden = false
             cancelledLabel.isHidden = false
-            classNameLabel.textColor = .fitnessDisabledGrey
+            classNameLabel.textColor = .gray03
         } else {
             hoursLabel.text = getHoursString(from: item)
         }
@@ -78,7 +76,7 @@ class TodaysClassListItemCell: ListItemCollectionViewCell<GymClassInstance> {
         imageView.contentMode = .scaleAspectFill
         contentView.addSubview(imageView)
 
-        cancelledView.backgroundColor = .fitnessRed
+        cancelledView.backgroundColor = .closedRed
         cancelledView.isHidden = true
         contentView.addSubview(cancelledView)
 
@@ -89,12 +87,12 @@ class TodaysClassListItemCell: ListItemCollectionViewCell<GymClassInstance> {
         contentView.addSubview(cancelledLabel)
 
         classNameLabel.font = ._16MontserratMedium
-        classNameLabel.textColor = .fitnessBlack
+        classNameLabel.textColor = .primaryBlack
         classNameLabel.sizeToFit()
         contentView.addSubview(classNameLabel)
 
         hoursLabel.font = ._12MontserratRegular
-        hoursLabel.textColor = .fitnessMediumClearGrey
+        hoursLabel.textColor = .gray05
         contentView.addSubview(hoursLabel)
 
         locationWidget.contentMode = .scaleAspectFit
@@ -102,7 +100,7 @@ class TodaysClassListItemCell: ListItemCollectionViewCell<GymClassInstance> {
         contentView.addSubview(locationWidget)
 
         locationNameLabel.font = ._12MontserratRegular
-        locationNameLabel.textColor = .fitnessClearGrey
+        locationNameLabel.textColor = .gray02
         contentView.addSubview(locationNameLabel)
     }
 

--- a/Uplift/Views/Range Slider/RangeSeekSlider.swift
+++ b/Uplift/Views/Range Slider/RangeSeekSlider.swift
@@ -208,6 +208,38 @@ import UIKit
         }
     }
 
+    /// Handle shadow radius (default 0.0)
+    @IBInspectable open var handleShadowRadius: CGFloat = 0.0 {
+        didSet {
+            leftHandle.shadowRadius = handleShadowRadius
+            rightHandle.shadowRadius = handleShadowRadius
+        }
+    }
+
+    /// Handle shadow opacity (default 0.0)
+    @IBInspectable open var handleShadowOpacity: Float = 0.0 {
+        didSet {
+            leftHandle.shadowOpacity = handleShadowOpacity
+            rightHandle.shadowOpacity = handleShadowOpacity
+        }
+    }
+
+    /// Handle shadow offset (default CGSize.zero)
+    @IBInspectable open var handleShadowOffset: CGSize = .zero {
+        didSet {
+            leftHandle.shadowOffset = handleShadowOffset
+            rightHandle.shadowOffset = handleShadowOffset
+        }
+    }
+
+    /// Handle shadow color
+    @IBInspectable open var handleShadowColor: UIColor? {
+        didSet {
+            leftHandle.shadowColor = handleShadowColor?.cgColor
+            rightHandle.shadowColor = handleShadowColor?.cgColor
+        }
+    }
+
     /// The label displayed in accessibility mode for minimum value handler. If not set, the default is empty String.
     @IBInspectable open var minLabelAccessibilityLabel: String?
 


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->
Updated colors and names in `UIColor+Shared` to match the style guide, update color/font use, and update shadows throughout to match final screen designs on Figma.


## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->
Biggest changes in: 
- `UIColor+Shared.swift` and replacing usages throughout app 
- `Histogram.swift`
- ClassList calendar header
- `FilterViewController.swift`
- a lot of little font changes and styling to match designs better

## Test Coverage

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->
Verified visually that app matches designs. 

## Related PRs or Issues 

<!-- List related PRs against other branches/repositories. -->
Addressed: #181, #143 


## Screenshots

<!-- This could include of screenshots of the new feature / proof that the changes work. -->

**New Histogram**

<img src="https://user-images.githubusercontent.com/20599510/67137512-9b408a80-f204-11e9-9f59-200ac02e7dd8.png" width = 40%>

**Updated Classes Page**

<img src="https://user-images.githubusercontent.com/20599510/67137495-6d5b4600-f204-11e9-86be-fa398c60a4ce.png" width = 40%>

<summary> Empty state fix </summary>

| iPhone 8 | iPhone 6s |
:-------------------------:|:-------------------------:
| <img src="https://user-images.githubusercontent.com/20599510/67137932-8666f580-f20a-11e9-8a86-c2bd4fc05a03.png" width=60%> | <img src="https://user-images.githubusercontent.com/20599510/67137962-f2e1f480-f20a-11e9-8741-85e2f330845f.png" width = 60%> |


