### PR TITLE
Fix facility time labels

### DIFF
--- a/Uplift/Views/FacilitiesDropdownHeaderView.swift
+++ b/Uplift/Views/FacilitiesDropdownHeaderView.swift
@@ -47,7 +47,6 @@ class FacilitiesDropdownHeaderView: DropdownHeaderView {
         headerNameLabel.textAlignment = .left
         addSubview(headerNameLabel)
 
-        headerOpenLabel.text = ""
         headerOpenLabel.font = ._16MontserratRegular
         headerOpenLabel.textAlignment = .center
         addSubview(headerOpenLabel)
@@ -55,6 +54,8 @@ class FacilitiesDropdownHeaderView: DropdownHeaderView {
         if let isFacilityOpen = getIsFacilityOpen(for: facility) {
             headerOpenLabel.text = isFacilityOpen ? ClientStrings.CommonStrings.open : ClientStrings.CommonStrings.closed
             headerOpenLabel.textColor = isFacilityOpen ? .accentOpen : .accentClosed
+        } else {
+            headerOpenLabel.text = ""
         }
 
         setupConstraints()

--- a/Uplift/Views/FacilitiesDropdownHeaderView.swift
+++ b/Uplift/Views/FacilitiesDropdownHeaderView.swift
@@ -47,10 +47,11 @@ class FacilitiesDropdownHeaderView: DropdownHeaderView {
         headerNameLabel.textAlignment = .left
         addSubview(headerNameLabel)
 
+        headerOpenLabel.text = ""
         headerOpenLabel.font = ._16MontserratRegular
         headerOpenLabel.textAlignment = .center
         addSubview(headerOpenLabel)
-
+        
         if let isFacilityOpen = getIsFacilityOpen(for: facility) {
             headerOpenLabel.text = isFacilityOpen ? ClientStrings.CommonStrings.open : ClientStrings.CommonStrings.closed
             headerOpenLabel.textColor = isFacilityOpen ? .accentOpen : .accentClosed

--- a/Uplift/Views/FacilitiesDropdownHeaderView.swift
+++ b/Uplift/Views/FacilitiesDropdownHeaderView.swift
@@ -50,7 +50,7 @@ class FacilitiesDropdownHeaderView: DropdownHeaderView {
         headerOpenLabel.font = ._16MontserratRegular
         headerOpenLabel.textAlignment = .center
         addSubview(headerOpenLabel)
-        
+
         if let isFacilityOpen = getIsFacilityOpen(for: facility) {
             headerOpenLabel.text = isFacilityOpen ? ClientStrings.CommonStrings.open : ClientStrings.CommonStrings.closed
             headerOpenLabel.textColor = isFacilityOpen ? .accentOpen : .accentClosed


### PR DESCRIPTION
## Overview

Fixes issues where the time labels on facility dropdown cells would erratically shift between OPEN and CLOSED upon tapping the dropdown.



## Changes Made

The issue was caused by reused dropdown cells having a label text and colour being set if the facility needed a time label, but the label not being set to an empty string if the facility did not need a label (ie, if the facility had no associated times).



## Test Coverage

Verified visually that the issue has been fixed.



## Screenshots (delete if not applicable)

See posted videos in #uplift-ios
