### PR TITLE
Replace old dropdown header with new UIView dropdown headers

### DIFF
--- a/Uplift.xcodeproj/project.pbxproj
+++ b/Uplift.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		035CB8CF23F06B890050A4B5 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 035CB8CE23F06B890050A4B5 /* GoogleService-Info.plist */; };
 		0C97AC292276840F0086D699 /* FacilityHoursCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C97AC282276840F0086D699 /* FacilityHoursCell.swift */; };
 		0C97AC2B2276841B0086D699 /* FacilityHoursHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C97AC2A2276841B0086D699 /* FacilityHoursHeaderView.swift */; };
 		1C1D283B2166E215003FE839 /* Keys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C1D283A2166E215003FE839 /* Keys.swift */; };
@@ -125,7 +126,6 @@
 		D95810AC216E960700D4436C /* RangeSeekSliderDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D95810AB216E960700D4436C /* RangeSeekSliderDelegate.swift */; };
 		D9936A29216D9FAA002802F4 /* NoClassesEmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9936A28216D9FAA002802F4 /* NoClassesEmptyStateView.swift */; };
 		E604DC1B233B1B18003598BC /* API.swift in Sources */ = {isa = PBXBuildFile; fileRef = E604DC1A233B1B18003598BC /* API.swift */; };
-		E604DC3F233B22C9003598BC /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E604DC3E233B22C9003598BC /* GoogleService-Info.plist */; };
 		E607CE29238FC026002DC297 /* EquipmentListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EC4B79A236CADD8006B67B3 /* EquipmentListCell.swift */; };
 		E62DB5212344907600ACAA1E /* ClientStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E62DB5202344907600ACAA1E /* ClientStrings.swift */; };
 		E644819C232DD34100BBF771 /* Keys.plist in Resources */ = {isa = PBXBuildFile; fileRef = E644819B232DD34100BBF771 /* Keys.plist */; };
@@ -137,6 +137,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		035CB8CE23F06B890050A4B5 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		0C97AC282276840F0086D699 /* FacilityHoursCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FacilityHoursCell.swift; sourceTree = "<group>"; };
 		0C97AC2A2276841B0086D699 /* FacilityHoursHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FacilityHoursHeaderView.swift; sourceTree = "<group>"; };
 		1C1D283A2166E215003FE839 /* Keys.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Keys.swift; sourceTree = "<group>"; };
@@ -261,7 +262,6 @@
 		D95810AB216E960700D4436C /* RangeSeekSliderDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangeSeekSliderDelegate.swift; sourceTree = "<group>"; };
 		D9936A28216D9FAA002802F4 /* NoClassesEmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoClassesEmptyStateView.swift; sourceTree = "<group>"; };
 		E604DC1A233B1B18003598BC /* API.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = API.swift; sourceTree = "<group>"; };
-		E604DC3E233B22C9003598BC /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		E62DB5202344907600ACAA1E /* ClientStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientStrings.swift; sourceTree = "<group>"; };
 		E644819B232DD34100BBF771 /* Keys.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Keys.plist; sourceTree = "<group>"; };
 		E6963C40238CF3E000ABC526 /* FacilitiesDropdownHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = FacilitiesDropdownHeaderView.swift; path = ../../FacilitiesDropdownHeaderView.swift; sourceTree = "<group>"; };
@@ -486,7 +486,7 @@
 				1C7847C3216E77E30066E0DA /* Assets.xcassets */,
 				C7DFABE22042081000545B0B /* Controllers */,
 				C75EC94E2059AC75007BC98A /* Extensions */,
-				E604DC3E233B22C9003598BC /* GoogleService-Info.plist */,
+				035CB8CE23F06B890050A4B5 /* GoogleService-Info.plist */,
 				D94BD3062159DA7D00C9214E /* graphql */,
 				C7EBD5B12062FDD800D76A8B /* Helpers */,
 				C7DFABDA204206E000545B0B /* Info.plist */,
@@ -714,7 +714,7 @@
 				C76A70B2205ED2E100E60CC8 /* Montserrat-Light.ttf in Resources */,
 				C76A70B4205ED2E900E60CC8 /* Montserrat-Medium.ttf in Resources */,
 				C7DFABD9204206E000545B0B /* LaunchScreen.storyboard in Resources */,
-				E604DC3F233B22C9003598BC /* GoogleService-Info.plist in Resources */,
+				035CB8CF23F06B890050A4B5 /* GoogleService-Info.plist in Resources */,
 				C76A70AC205EC7B700E60CC8 /* BebasNeue-Regular.ttf in Resources */,
 				8D61D8832162F15900969DF4 /* Montserrat-SemiBold.ttf in Resources */,
 				1C46740D215FEB1D000AEDF0 /* gymClassInstanceQueries.graphql in Resources */,

--- a/Uplift/Controllers/FilterViewController.swift
+++ b/Uplift/Controllers/FilterViewController.swift
@@ -382,7 +382,7 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
         classTypeInstructorDivider.snp.remakeConstraints { make in
             make.width.centerX.equalToSuperview()
             make.top.equalTo(classTypeDropdownFooter.snp.bottom)
-            make.bottom.equalTo(classTypeDropdown.snp.bottom).offset(1)
+            make.bottom.equalTo(classTypeDropdownFooter.snp.bottom).offset(1)
         }
 
         // INSTRUCTOR SECTION
@@ -420,7 +420,7 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
 
         instructorDivider.snp.remakeConstraints { make in
             make.width.centerX.equalToSuperview()
-            make.top.equalTo(instructorDropdown.snp.bottom)
+            make.top.equalTo(instructorDropdownFooter.snp.bottom)
             make.height.equalTo(1)
             make.bottom.equalToSuperview()
         }

--- a/Uplift/Controllers/FilterViewController.swift
+++ b/Uplift/Controllers/FilterViewController.swift
@@ -151,7 +151,11 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
         contentView.addSubview(classTypeDropdownHeader)
         
         classTypeDropdownFooter = DropdownFooterView(frame: .zero)
+        classTypeDropdownFooter.clipsToBounds = true
         contentView.addSubview(classTypeDropdownFooter)
+        
+        let classTypeGesture = UITapGestureRecognizer(target: self, action: #selector(self.dropHideClasses(sender:) ))
+        classTypeDropdownFooter.addGestureRecognizer(classTypeGesture)
         
         classTypeDropdown = UITableView(frame: .zero)
         classTypeDropdown.separatorStyle = .none
@@ -184,8 +188,12 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
         contentView.addSubview(instructorDropdownHeader)
         
         instructorDropdownFooter = DropdownFooterView(frame: .zero)
+        instructorDropdownFooter.clipsToBounds = true
         contentView.addSubview(instructorDropdownFooter)
         
+        let instructorGesture = UITapGestureRecognizer(target: self, action: #selector(self.dropHideInstructors(sender:) ))
+        instructorDropdownFooter.addGestureRecognizer(instructorGesture)
+               
         instructorDropdown = UITableView(frame: .zero)
         instructorDropdown.separatorStyle = .none
         instructorDropdown.bounces = false
@@ -214,7 +222,6 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
 
         setupConstraints()
         setupDropdownHeaderViews()
-        setupTableFooterViews()
     }
 
     // MARK: - SETUP WRAPPING VIEWS
@@ -424,6 +431,8 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
             make.height.equalTo(1)
             make.bottom.equalToSuperview()
         }
+        
+        updateTableFooterViews()
     }
     
     func setupDropdownHeaderViews() {
@@ -437,16 +446,12 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
            instructorDropdownHeader.addGestureRecognizer(instructorGesture)
     }
     
-    func setupTableFooterViews() {
-        let instructorGesture = UITapGestureRecognizer(target: self, action: #selector(self.dropHideInstructors(sender:) ))
-        instructorDropdownFooter.addGestureRecognizer(instructorGesture)
+    func updateTableFooterViews() {
         if (instructorDropdownData.dropStatus == .half) {
             instructorDropdownFooter.showHideLabel.text = ClientStrings.Filter.dropdownShowInstructors
         } else {
             instructorDropdownFooter.showHideLabel.text = ClientStrings.Dropdown.collapse
         }
-        let classTypeGesture = UITapGestureRecognizer(target: self, action: #selector(self.dropHideClasses(sender:) ))
-        classTypeDropdownFooter.addGestureRecognizer(classTypeGesture)
         if (classTypeDropdownData.dropStatus == .half) {
             classTypeDropdownFooter.showHideLabel.text = ClientStrings.Filter.dropdownShowClassTypes
         } else {

--- a/Uplift/Controllers/FilterViewController.swift
+++ b/Uplift/Controllers/FilterViewController.swift
@@ -309,13 +309,13 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
     func setupConstraints() {
         // COLLECTION VIEW SECTION
         collectionViewTitle.snp.remakeConstraints { make in
-            make.left.equalToSuperview().offset(16)
+            make.leading.equalToSuperview().offset(16)
             make.top.equalToSuperview().offset(20)
             make.bottom.equalTo(collectionViewTitle.snp.top).offset(15)
         }
 
         gymCollectionView.snp.remakeConstraints { make in
-            make.left.right.equalToSuperview()
+            make.leading.trailing.equalToSuperview()
             make.top.equalToSuperview().offset(51)
             make.bottom.equalTo(collectionViewTitle.snp.bottom).offset(47)
         }
@@ -328,13 +328,13 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
         }
 
         startTimeTitleLabel.snp.remakeConstraints { make in
-            make.left.equalToSuperview().offset(16)
+            make.leading.equalToSuperview().offset(16)
             make.top.equalTo(fitnessCenterStartTimeDivider.snp.bottom).offset(20)
             make.bottom.equalTo(fitnessCenterStartTimeDivider.snp.bottom).offset(35)
         }
 
         startTimeLabel.snp.remakeConstraints { make in
-            make.right.equalToSuperview().offset(-22)
+            make.trailing.equalToSuperview().offset(-22)
             make.top.equalTo(fitnessCenterStartTimeDivider.snp.bottom).offset(20)
             make.bottom.equalTo(fitnessCenterStartTimeDivider.snp.bottom).offset(36)
         }
@@ -355,13 +355,13 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
         // CLASS TYPE SECTION
         classTypeDropdownHeader.snp.remakeConstraints { make in
             make.top.equalTo(startTimeClassTypeDivider.snp.bottom)
-            make.left.right.equalToSuperview()
+            make.leading.trailing.equalToSuperview()
             make.height.equalTo(55)
         }
         
         classTypeDropdown.snp.remakeConstraints { make in
             make.top.equalTo(classTypeDropdownHeader.snp.bottom)
-            make.left.right.equalToSuperview()
+            make.leading.trailing.equalToSuperview()
             
             if let dropStatus = classTypeDropdownData.dropStatus {
                 switch dropStatus {
@@ -379,7 +379,7 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
 
         classTypeDropdownFooter.snp.remakeConstraints { make in
             make.top.equalTo(classTypeDropdown.snp.bottom)
-            make.left.right.equalToSuperview()
+            make.leading.trailing.equalToSuperview()
             
             if let dropStatus = classTypeDropdownData.dropStatus {
                 switch dropStatus {
@@ -402,13 +402,13 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
         // INSTRUCTOR SECTION
         instructorDropdownHeader.snp.remakeConstraints { make in
             make.top.equalTo(classTypeInstructorDivider.snp.bottom)
-            make.left.right.equalToSuperview()
+            make.leading.trailing.equalToSuperview()
             make.height.equalTo(55)
         }
         
         instructorDropdown.snp.remakeConstraints { make in
             make.top.equalTo(instructorDropdownHeader.snp.bottom)
-            make.left.right.equalToSuperview()
+            make.leading.trailing.equalToSuperview()
             
             if let dropStatus = instructorDropdownData.dropStatus {
                 switch dropStatus {
@@ -426,7 +426,7 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
         
         instructorDropdownFooter.snp.remakeConstraints { make in
             make.top.equalTo(instructorDropdown.snp.bottom)
-            make.left.right.equalToSuperview()
+            make.leading.trailing.equalToSuperview()
 
             if let dropStatus = instructorDropdownData.dropStatus {
                 switch dropStatus {

--- a/Uplift/Controllers/FilterViewController.swift
+++ b/Uplift/Controllers/FilterViewController.swift
@@ -436,14 +436,17 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
     }
     
     func setupDropdownHeaderViews() {
-           classTypeDropdownHeader.titleLabel.text = ClientStrings.Filter.selectClassTypeSection
-           instructorDropdownHeader.titleLabel.text = ClientStrings.Filter.selectInstructorSection
-          
-           let classGesture = UITapGestureRecognizer(target: self, action: #selector(self.dropClasses(sender:) ))
-           classTypeDropdownHeader.addGestureRecognizer(classGesture)
+        classTypeDropdownHeader.titleLabel.text = ClientStrings.Filter.selectClassTypeSection
+        instructorDropdownHeader.titleLabel.text = ClientStrings.Filter.selectInstructorSection
+        
+        let classGesture = UITapGestureRecognizer(target: self, action: #selector(self.dropClasses(sender:) ))
+        classTypeDropdownHeader.addGestureRecognizer(classGesture)
            
-           let instructorGesture = UITapGestureRecognizer(target: self, action: #selector(self.dropInstructors(sender:) ))
-           instructorDropdownHeader.addGestureRecognizer(instructorGesture)
+        let instructorGesture = UITapGestureRecognizer(target: self, action: #selector(self.dropInstructors(sender:) ))
+        instructorDropdownHeader.addGestureRecognizer(instructorGesture)
+        
+        classTypeDropdownHeader.updateDropdownHeader(selectedFilters: selectedClasses)
+        instructorDropdownHeader.updateDropdownHeader(selectedFilters: selectedInstructors)
     }
     
     func updateTableFooterViews() {
@@ -745,12 +748,12 @@ extension FilterViewController: UITableViewDelegate {
                     let name = selectedClasses[i]
                     if name == cell.titleLabel.text! {
                         selectedClasses.remove(at: i)
-//                        (classTypeDropdown.headerView(forSection: 0) as! DropdownHeaderView).updateDropdownHeader(selectedFilters: selectedClasses)
+                        classTypeDropdownHeader.updateDropdownHeader(selectedFilters: selectedClasses)
                         return
                     }
                 }
             }
-//            (classTypeDropdown.headerView(forSection: 0) as! DropdownHeaderView).updateDropdownHeader(selectedFilters: selectedClasses)
+            classTypeDropdownHeader.updateDropdownHeader(selectedFilters: selectedClasses)
         } else {
             if shouldAppend {
                 selectedInstructors.append(cell.titleLabel.text!)
@@ -759,12 +762,12 @@ extension FilterViewController: UITableViewDelegate {
                     let name = selectedInstructors[i]
                     if name == cell.titleLabel.text! {
                         selectedInstructors.remove(at: i)
-//                        (instructorDropdown.headerView(forSection: 0) as! DropdownHeaderView).updateDropdownHeader(selectedFilters: selectedInstructors)
+                        instructorDropdownHeader.updateDropdownHeader(selectedFilters: selectedInstructors)
                         return
                     }
                 }
             }
-//            (instructorDropdown.headerView(forSection: 0) as! DropdownHeaderView).updateDropdownHeader(selectedFilters: selectedInstructors)
+            instructorDropdownHeader.updateDropdownHeader(selectedFilters: selectedInstructors)
         }
     }
 

--- a/Uplift/Controllers/FilterViewController.swift
+++ b/Uplift/Controllers/FilterViewController.swift
@@ -152,7 +152,7 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
         classTypeDropdown.separatorStyle = .none
         classTypeDropdown.showsVerticalScrollIndicator = false
         classTypeDropdown.bounces = false
-
+        
         classTypeDropdown.register(DropdownViewCell.self, forCellReuseIdentifier: DropdownViewCell.identifier)
         classTypeDropdown.register(DropdownFooterView.self, forHeaderFooterViewReuseIdentifier: DropdownFooterView.identifier)
 
@@ -394,6 +394,19 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
             make.bottom.equalToSuperview()
         }
     }
+    
+    func setupDropdownHeaderViews() {
+           guard let classHeader = classTypeDropdownHeader as? DropdownHeaderView, let instructorHeader = instructorDropdownHeader as? DropdownHeaderView else { return }
+           
+           classHeader.titleLabel.text = ClientStrings.Filter.selectClassTypeSection
+           instructorHeader.titleLabel.text = ClientStrings.Filter.selectInstructorSection
+          
+           let classGesture = UITapGestureRecognizer(target: self, action: #selector(self.dropClasses(sender:) ))
+           classHeader.addGestureRecognizer(classGesture)
+           
+           let instructorGesture = UITapGestureRecognizer(target: self, action: #selector(self.dropInstructors(sender:) ))
+           instructorHeader.addGestureRecognizer(instructorGesture)
+    }
 
     // MARK: - NAVIGATION BAR BUTTONS FUNCTIONS
     @objc func done() {
@@ -616,7 +629,7 @@ extension FilterViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         var numberOfRows = 0
         if tableView == instructorDropdown {
-            if instructorDropdownData.completed == false {
+            if !instructorDropdownData.completed {
                 return 0
             }
             switch instructorDropdownData.dropStatus! {
@@ -628,7 +641,7 @@ extension FilterViewController: UITableViewDataSource {
                 numberOfRows = instructorDropdownData.titles.count
             }
         } else if tableView == classTypeDropdown {
-            if classTypeDropdownData.completed == false {
+            if !classTypeDropdownData.completed {
                 return 0
             }
 
@@ -712,10 +725,6 @@ extension FilterViewController: UITableViewDelegate {
         return 32
     }
 
-    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return 55
-    }
-
     func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
         var height: CGFloat = 0
         if tableView == classTypeDropdown {
@@ -758,34 +767,4 @@ extension FilterViewController: UITableViewDelegate {
         }
         return footer
     }
-    
-    func setupDropdownHeaderViews() {
-        guard let classHeader = classTypeDropdownHeader as? DropdownHeaderView, let instructorHeader = instructorDropdownHeader as? DropdownHeaderView else { return }
-        
-        classHeader.titleLabel.text = ClientStrings.Filter.selectClassTypeSection
-        instructorHeader.titleLabel.text = ClientStrings.Filter.selectInstructorSection
-       
-        let classGesture = UITapGestureRecognizer(target: self, action: #selector(self.dropClasses(sender:) ))
-        classHeader.addGestureRecognizer(classGesture)
-        
-        let instructorGesture = UITapGestureRecognizer(target: self, action: #selector(self.dropInstructors(sender:) ))
-        instructorHeader.addGestureRecognizer(instructorGesture)
-    }
-
-//    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-//        let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: DropdownHeaderView.identifier) as! DropdownHeaderView
-
-//        if tableView == instructorDropdown {
-//            header.titleLabel.text = ClientStrings.Filter.selectInstructorSection
-//            header.updateDropdownHeader(selectedFilters: selectedInstructors)
-//            let gesture = UITapGestureRecognizer(target: self, action: #selector(self.dropInstructors(sender:) ))
-//            header.addGestureRecognizer(gesture)
-//        } else if tableView == classTypeDropdown {
-//            header.titleLabel.text = ClientStrings.Filter.selectClassTypeSection
-//            header.updateDropdownHeader(selectedFilters: selectedClasses)
-//            let gesture = UITapGestureRecognizer(target: self, action: #selector(self.dropClasses(sender:) ))
-//            header.addGestureRecognizer(gesture)
-//        }
-//        return header
-//    }
 }

--- a/Uplift/Controllers/FilterViewController.swift
+++ b/Uplift/Controllers/FilterViewController.swift
@@ -147,23 +147,22 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
         contentView.addSubview(startTimeClassTypeDivider)
 
         // CLASS TYPE SECTION
-        classTypeDropdownHeader = DropdownHeaderView(frame: .zero)
+        classTypeDropdownHeader = DropdownHeaderView(frame: .zero, title: ClientStrings.Filter.selectClassTypeSection)
         contentView.addSubview(classTypeDropdownHeader)
         
         classTypeDropdownFooter = DropdownFooterView(frame: .zero)
         classTypeDropdownFooter.clipsToBounds = true
         contentView.addSubview(classTypeDropdownFooter)
         
-        let classTypeGesture = UITapGestureRecognizer(target: self, action: #selector(self.dropHideClasses(sender:) ))
-        classTypeDropdownFooter.addGestureRecognizer(classTypeGesture)
+        let toggleMoreClasses = UITapGestureRecognizer(target: self, action: #selector(self.dropHideClasses(sender:) ))
+        classTypeDropdownFooter.addGestureRecognizer(toggleMoreClasses)
         
-        classTypeDropdown = UITableView(frame: .zero)
+        classTypeDropdown = UITableView()
         classTypeDropdown.separatorStyle = .none
         classTypeDropdown.showsVerticalScrollIndicator = false
         classTypeDropdown.bounces = false
-        
-        classTypeDropdown.register(DropdownViewCell.self, forCellReuseIdentifier: DropdownViewCell.identifier)
 
+        classTypeDropdown.register(DropdownViewCell.self, forCellReuseIdentifier: DropdownViewCell.identifier)
         classTypeDropdown.delegate = self
         classTypeDropdown.dataSource = self
         contentView.addSubview(classTypeDropdown)
@@ -184,17 +183,17 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
         }
 
         // INSTRUCTOR SECTION
-        instructorDropdownHeader = DropdownHeaderView(frame: .zero)
+        instructorDropdownHeader = DropdownHeaderView(frame: .zero, title: ClientStrings.Filter.selectInstructorSection)
         contentView.addSubview(instructorDropdownHeader)
         
         instructorDropdownFooter = DropdownFooterView(frame: .zero)
         instructorDropdownFooter.clipsToBounds = true
         contentView.addSubview(instructorDropdownFooter)
         
-        let instructorGesture = UITapGestureRecognizer(target: self, action: #selector(self.dropHideInstructors(sender:) ))
-        instructorDropdownFooter.addGestureRecognizer(instructorGesture)
+        let toggleMoreInstructors = UITapGestureRecognizer(target: self, action: #selector(self.dropHideInstructors(sender:) ))
+        instructorDropdownFooter.addGestureRecognizer(toggleMoreInstructors)
                
-        instructorDropdown = UITableView(frame: .zero)
+        instructorDropdown = UITableView()
         instructorDropdown.separatorStyle = .none
         instructorDropdown.bounces = false
         instructorDropdown.showsVerticalScrollIndicator = false
@@ -363,33 +362,41 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
         classTypeDropdown.snp.remakeConstraints { make in
             make.top.equalTo(classTypeDropdownHeader.snp.bottom)
             make.left.right.equalToSuperview()
-
-            switch classTypeDropdownData.dropStatus! {
-            case .up:
+            
+            if let dropStatus = classTypeDropdownData.dropStatus {
+                switch dropStatus {
+                    case .up:
+                        make.height.equalTo(0)
+                    case .half:
+                        make.height.equalTo(3 * 32)
+                    case .down:
+                        make.height.equalTo(classTypeDropdown.numberOfRows(inSection: 0) * 32)
+                }
+            } else {
                 make.height.equalTo(0)
-            case .half:
-                make.height.equalTo(3*32)
-            case .down:
-                make.height.equalTo(classTypeDropdown.numberOfRows(inSection: 0)*32)
             }
         }
 
         classTypeDropdownFooter.snp.remakeConstraints { make in
             make.top.equalTo(classTypeDropdown.snp.bottom)
             make.left.right.equalToSuperview()
-
-            switch classTypeDropdownData.dropStatus! {
-            case .up:
+            
+            if let dropStatus = classTypeDropdownData.dropStatus {
+                switch dropStatus {
+                    case .up:
+                        make.height.equalTo(0)
+                    case .half, .down:
+                        make.height.equalTo(32)
+                }
+            } else {
                 make.height.equalTo(0)
-            case .half, .down:
-                make.height.equalTo(32)
             }
         }
         
         classTypeInstructorDivider.snp.remakeConstraints { make in
             make.width.centerX.equalToSuperview()
             make.top.equalTo(classTypeDropdownFooter.snp.bottom)
-            make.bottom.equalTo(classTypeDropdownFooter.snp.bottom).offset(1)
+            make.bottom.equalTo(classTypeDropdownFooter).offset(1)
         }
 
         // INSTRUCTOR SECTION
@@ -402,14 +409,18 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
         instructorDropdown.snp.remakeConstraints { make in
             make.top.equalTo(instructorDropdownHeader.snp.bottom)
             make.left.right.equalToSuperview()
-
-            switch instructorDropdownData.dropStatus! {
-            case .up:
+            
+            if let dropStatus = instructorDropdownData.dropStatus {
+                switch dropStatus {
+                    case .up:
+                        make.height.equalTo(0)
+                    case .half:
+                        make.height.equalTo(3 * 32)
+                    case .down:
+                        make.height.equalTo(instructorDropdown.numberOfRows(inSection: 0) * 32)
+                }
+            } else {
                 make.height.equalTo(0)
-            case .half:
-                make.height.equalTo(3*32)
-            case .down:
-                make.height.equalTo(instructorDropdown.numberOfRows(inSection: 0)*32)
             }
         }
         
@@ -417,11 +428,15 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
             make.top.equalTo(instructorDropdown.snp.bottom)
             make.left.right.equalToSuperview()
 
-            switch instructorDropdownData.dropStatus! {
-            case .up:
+            if let dropStatus = instructorDropdownData.dropStatus {
+                switch dropStatus {
+                    case .up:
+                        make.height.equalTo(0)
+                    case .half, .down:
+                        make.height.equalTo(32)
+                }
+            } else {
                 make.height.equalTo(0)
-            case .half, .down:
-                make.height.equalTo(32)
             }
         }
 
@@ -436,30 +451,23 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
     }
     
     func setupDropdownHeaderViews() {
-        classTypeDropdownHeader.titleLabel.text = ClientStrings.Filter.selectClassTypeSection
-        instructorDropdownHeader.titleLabel.text = ClientStrings.Filter.selectInstructorSection
-        
-        let classGesture = UITapGestureRecognizer(target: self, action: #selector(self.dropClasses(sender:) ))
-        classTypeDropdownHeader.addGestureRecognizer(classGesture)
+        let toggleClasses = UITapGestureRecognizer(target: self, action: #selector(self.dropClasses(sender:) ))
+        classTypeDropdownHeader.addGestureRecognizer(toggleClasses)
            
-        let instructorGesture = UITapGestureRecognizer(target: self, action: #selector(self.dropInstructors(sender:) ))
-        instructorDropdownHeader.addGestureRecognizer(instructorGesture)
+        let toggleInstructors = UITapGestureRecognizer(target: self, action: #selector(self.dropInstructors(sender:) ))
+        instructorDropdownHeader.addGestureRecognizer(toggleInstructors)
         
         classTypeDropdownHeader.updateDropdownHeader(selectedFilters: selectedClasses)
         instructorDropdownHeader.updateDropdownHeader(selectedFilters: selectedInstructors)
     }
     
     func updateTableFooterViews() {
-        if (instructorDropdownData.dropStatus == .half) {
-            instructorDropdownFooter.showHideLabel.text = ClientStrings.Filter.dropdownShowInstructors
-        } else {
-            instructorDropdownFooter.showHideLabel.text = ClientStrings.Dropdown.collapse
-        }
-        if (classTypeDropdownData.dropStatus == .half) {
-            classTypeDropdownFooter.showHideLabel.text = ClientStrings.Filter.dropdownShowClassTypes
-        } else {
-            classTypeDropdownFooter.showHideLabel.text = ClientStrings.Dropdown.collapse
-        }
+        instructorDropdownFooter.showHideLabel.text = instructorDropdownData.dropStatus == .half
+            ? ClientStrings.Filter.dropdownShowInstructors
+            : ClientStrings.Dropdown.collapse
+        classTypeDropdownFooter.showHideLabel.text = classTypeDropdownData.dropStatus == .half
+            ? ClientStrings.Filter.dropdownShowClassTypes
+            : ClientStrings.Dropdown.collapse
     }
 
     // MARK: - NAVIGATION BAR BUTTONS FUNCTIONS
@@ -741,7 +749,7 @@ extension FilterViewController: UITableViewDelegate {
         shouldAppend = !shouldAppend
 
         if tableView == classTypeDropdown {
-            if (shouldAppend) {
+            if shouldAppend {
                 selectedClasses.append(cell.titleLabel.text!)
             } else {
                 for i in 0..<selectedClasses.count {

--- a/Uplift/Controllers/FilterViewController.swift
+++ b/Uplift/Controllers/FilterViewController.swift
@@ -148,7 +148,7 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
         classTypeDropdownHeader = DropdownHeaderView(frame: .zero)
         contentView.addSubview(classTypeDropdownHeader)
         
-        classTypeDropdown = UITableView(frame: .zero, style: .grouped)
+        classTypeDropdown = UITableView(frame: .zero)
         classTypeDropdown.separatorStyle = .none
         classTypeDropdown.showsVerticalScrollIndicator = false
         classTypeDropdown.bounces = false
@@ -179,7 +179,7 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
         instructorDropdownHeader = DropdownHeaderView(frame: .zero)
         contentView.addSubview(instructorDropdownHeader)
         
-        instructorDropdown = UITableView(frame: .zero, style: .grouped)
+        instructorDropdown = UITableView(frame: .zero)
         instructorDropdown.separatorStyle = .none
         instructorDropdown.bounces = false
         instructorDropdown.showsVerticalScrollIndicator = false
@@ -691,7 +691,7 @@ extension FilterViewController: UITableViewDelegate {
         shouldAppend = !shouldAppend
 
         if tableView == classTypeDropdown {
-            if(shouldAppend) {
+            if (shouldAppend) {
                 selectedClasses.append(cell.titleLabel.text!)
             } else {
                 for i in 0..<selectedClasses.count {

--- a/Uplift/Controllers/FilterViewController.swift
+++ b/Uplift/Controllers/FilterViewController.swift
@@ -52,12 +52,14 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
     var startTime = "6:00AM"
     var startTimeClassTypeDivider: UIView!
 
+    var classTypeDropdownHeader: UIView!
     var classTypeDropdown: UITableView!
     var classTypeDropdownData: DropdownData!
     var classTypeInstructorDivider: UIView!
     var selectedClasses: [String] = []
 
     var instructorDivider: UIView!
+    var instructorDropdownHeader: UIView!
     var instructorDropdown: UITableView!
     var instructorDropdownData: DropdownData!
     var selectedInstructors: [String] = []
@@ -143,13 +145,15 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
         contentView.addSubview(startTimeClassTypeDivider)
 
         // CLASS TYPE SECTION
+        classTypeDropdownHeader = DropdownHeaderView(frame: .zero)
+        contentView.addSubview(classTypeDropdownHeader)
+        
         classTypeDropdown = UITableView(frame: .zero, style: .grouped)
         classTypeDropdown.separatorStyle = .none
         classTypeDropdown.showsVerticalScrollIndicator = false
         classTypeDropdown.bounces = false
 
         classTypeDropdown.register(DropdownViewCell.self, forCellReuseIdentifier: DropdownViewCell.identifier)
-        classTypeDropdown.register(OldDropdownHeaderView.self, forHeaderFooterViewReuseIdentifier: OldDropdownHeaderView.identifier)
         classTypeDropdown.register(DropdownFooterView.self, forHeaderFooterViewReuseIdentifier: DropdownFooterView.identifier)
 
         classTypeDropdown.delegate = self
@@ -172,13 +176,15 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
         }
 
         // INSTRUCTOR SECTION
+        instructorDropdownHeader = DropdownHeaderView(frame: .zero)
+        contentView.addSubview(instructorDropdownHeader)
+        
         instructorDropdown = UITableView(frame: .zero, style: .grouped)
         instructorDropdown.separatorStyle = .none
         instructorDropdown.bounces = false
         instructorDropdown.showsVerticalScrollIndicator = false
 
         instructorDropdown.register(DropdownViewCell.self, forCellReuseIdentifier: DropdownViewCell.identifier)
-        instructorDropdown.register(OldDropdownHeaderView.self, forHeaderFooterViewReuseIdentifier: OldDropdownHeaderView.identifier)
         instructorDropdown.register(DropdownFooterView.self, forHeaderFooterViewReuseIdentifier: DropdownFooterView.identifier)
 
         instructorDropdown.delegate = self
@@ -201,6 +207,7 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
         }
 
         setupConstraints()
+        setupDropdownHeaderViews()
     }
 
     // MARK: - SETUP WRAPPING VIEWS
@@ -333,17 +340,23 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
         }
 
         // CLASS TYPE SECTION
-        classTypeDropdown.snp.remakeConstraints { make in
+        classTypeDropdownHeader.snp.remakeConstraints { make in
             make.top.equalTo(startTimeClassTypeDivider.snp.bottom)
+            make.left.right.equalToSuperview()
+            make.height.equalTo(55)
+        }
+        
+        classTypeDropdown.snp.remakeConstraints { make in
+            make.top.equalTo(classTypeDropdownHeader.snp.bottom)
             make.left.right.equalToSuperview()
 
             switch classTypeDropdownData.dropStatus! {
             case .up:
-                make.height.equalTo(55)
+                make.height.equalTo(0)
             case .half:
-                make.height.equalTo(55 + 32 + 3*32)
+                make.height.equalTo(32 + 3*32)
             case .down:
-                make.height.equalTo(55 + 32 + classTypeDropdown.numberOfRows(inSection: 0)*32)
+                make.height.equalTo(32 + classTypeDropdown.numberOfRows(inSection: 0)*32)
             }
         }
 
@@ -354,17 +367,23 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
         }
 
         // INSTRUCTOR SECTION
-        instructorDropdown.snp.remakeConstraints { make in
+        instructorDropdownHeader.snp.remakeConstraints { make in
             make.top.equalTo(classTypeInstructorDivider.snp.bottom)
+            make.left.right.equalToSuperview()
+            make.height.equalTo(55)
+        }
+        
+        instructorDropdown.snp.remakeConstraints { make in
+            make.top.equalTo(instructorDropdownHeader.snp.bottom)
             make.left.right.equalToSuperview()
 
             switch instructorDropdownData.dropStatus! {
             case .up:
-                make.height.equalTo(55)
+                make.height.equalTo(0)
             case .half:
-                make.height.equalTo(55 + 32 + 3*32)
+                make.height.equalTo(32 + 3*32)
             case .down:
-                make.height.equalTo(55 + 32 + instructorDropdown.numberOfRows(inSection: 0)*32)
+                make.height.equalTo(32 + instructorDropdown.numberOfRows(inSection: 0)*32)
             }
         }
 
@@ -431,9 +450,8 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
         var modifiedIndices: [IndexPath] = []
 
         if instructorDropdownData.dropStatus == .half || instructorDropdownData.dropStatus == .down {
-            if let instructorDropdown = instructorDropdown.headerView(forSection: 0) as? OldDropdownHeaderView {
-                instructorDropdown.downArrow.image = .none
-                instructorDropdown.rightArrow.image = UIImage(named: ImageNames.rightArrow)
+            if let instructorDropdown = instructorDropdownHeader as? DropdownHeaderView {
+                instructorDropdown.rotateArrowUp()
             }
             instructorDropdownData.dropStatus = .up
             var i = 0
@@ -443,9 +461,8 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
             }
             instructorDropdown.deleteRows(at: modifiedIndices, with: .none)
         } else {
-            if let instructorDropdown = instructorDropdown.headerView(forSection: 0) as? OldDropdownHeaderView {
-                instructorDropdown.downArrow.image = UIImage(named: ImageNames.downArrow)
-                instructorDropdown.rightArrow.image = .none
+            if let instructorDropdown = instructorDropdownHeader as? DropdownHeaderView {
+                instructorDropdown.rotateArrowDown()
             }
             instructorDropdownData.dropStatus = .half
             for i in [0, 1, 2] {
@@ -467,8 +484,7 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
         var modifiedIndices: [IndexPath] = []
 
         if classTypeDropdownData.dropStatus == .half || classTypeDropdownData.dropStatus == .down {
-            (classTypeDropdown.headerView(forSection: 0) as! OldDropdownHeaderView).downArrow.image = .none
-            (classTypeDropdown.headerView(forSection: 0) as! OldDropdownHeaderView).rightArrow.image = UIImage(named: ImageNames.rightArrow)
+            (classTypeDropdownHeader as! DropdownHeaderView).rotateArrowUp()
             classTypeDropdownData.dropStatus = .up
             var i = 0
             while i < classTypeDropdown.numberOfRows(inSection: 0) {
@@ -477,8 +493,7 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
             }
             classTypeDropdown.deleteRows(at: modifiedIndices, with: .none)
         } else {
-            (classTypeDropdown.headerView(forSection: 0) as! OldDropdownHeaderView).downArrow.image = UIImage(named: ImageNames.downArrow)
-            (classTypeDropdown.headerView(forSection: 0) as! OldDropdownHeaderView).rightArrow.image = .none
+            (classTypeDropdownHeader as! DropdownHeaderView).rotateArrowDown()
             classTypeDropdownData.dropStatus = .half
             for i in [0, 1, 2] {
                 modifiedIndices.append(IndexPath(row: i, section: 0))
@@ -670,12 +685,12 @@ extension FilterViewController: UITableViewDelegate {
                     let name = selectedClasses[i]
                     if name == cell.titleLabel.text! {
                         selectedClasses.remove(at: i)
-                        (classTypeDropdown.headerView(forSection: 0) as! OldDropdownHeaderView).updateDropdownHeader(selectedFilters: selectedClasses)
+//                        (classTypeDropdown.headerView(forSection: 0) as! DropdownHeaderView).updateDropdownHeader(selectedFilters: selectedClasses)
                         return
                     }
                 }
             }
-            (classTypeDropdown.headerView(forSection: 0) as! OldDropdownHeaderView).updateDropdownHeader(selectedFilters: selectedClasses)
+//            (classTypeDropdown.headerView(forSection: 0) as! DropdownHeaderView).updateDropdownHeader(selectedFilters: selectedClasses)
         } else {
             if shouldAppend {
                 selectedInstructors.append(cell.titleLabel.text!)
@@ -684,12 +699,12 @@ extension FilterViewController: UITableViewDelegate {
                     let name = selectedInstructors[i]
                     if name == cell.titleLabel.text! {
                         selectedInstructors.remove(at: i)
-                        (instructorDropdown.headerView(forSection: 0) as! OldDropdownHeaderView).updateDropdownHeader(selectedFilters: selectedInstructors)
+//                        (instructorDropdown.headerView(forSection: 0) as! DropdownHeaderView).updateDropdownHeader(selectedFilters: selectedInstructors)
                         return
                     }
                 }
             }
-            (instructorDropdown.headerView(forSection: 0) as! OldDropdownHeaderView).updateDropdownHeader(selectedFilters: selectedInstructors)
+//            (instructorDropdown.headerView(forSection: 0) as! DropdownHeaderView).updateDropdownHeader(selectedFilters: selectedInstructors)
         }
     }
 
@@ -743,22 +758,34 @@ extension FilterViewController: UITableViewDelegate {
         }
         return footer
     }
-
-    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: OldDropdownHeaderView.identifier) as! OldDropdownHeaderView
-
-        if tableView == instructorDropdown {
-            header.titleLabel.text = ClientStrings.Filter.selectInstructorSection
-            header.updateDropdownHeader(selectedFilters: selectedInstructors)
-            let gesture = UITapGestureRecognizer(target: self, action: #selector(self.dropInstructors(sender:) ))
-            header.addGestureRecognizer(gesture)
-        } else if tableView == classTypeDropdown {
-            header.titleLabel.text = ClientStrings.Filter.selectClassTypeSection
-            header.updateDropdownHeader(selectedFilters: selectedClasses)
-            let gesture = UITapGestureRecognizer(target: self, action: #selector(self.dropClasses(sender:) ))
-            header.addGestureRecognizer(gesture)
-        }
-
-        return header
+    
+    func setupDropdownHeaderViews() {
+        guard let classHeader = classTypeDropdownHeader as? DropdownHeaderView, let instructorHeader = instructorDropdownHeader as? DropdownHeaderView else { return }
+        
+        classHeader.titleLabel.text = ClientStrings.Filter.selectClassTypeSection
+        instructorHeader.titleLabel.text = ClientStrings.Filter.selectInstructorSection
+       
+        let classGesture = UITapGestureRecognizer(target: self, action: #selector(self.dropClasses(sender:) ))
+        classHeader.addGestureRecognizer(classGesture)
+        
+        let instructorGesture = UITapGestureRecognizer(target: self, action: #selector(self.dropInstructors(sender:) ))
+        instructorHeader.addGestureRecognizer(instructorGesture)
     }
+
+//    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+//        let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: DropdownHeaderView.identifier) as! DropdownHeaderView
+
+//        if tableView == instructorDropdown {
+//            header.titleLabel.text = ClientStrings.Filter.selectInstructorSection
+//            header.updateDropdownHeader(selectedFilters: selectedInstructors)
+//            let gesture = UITapGestureRecognizer(target: self, action: #selector(self.dropInstructors(sender:) ))
+//            header.addGestureRecognizer(gesture)
+//        } else if tableView == classTypeDropdown {
+//            header.titleLabel.text = ClientStrings.Filter.selectClassTypeSection
+//            header.updateDropdownHeader(selectedFilters: selectedClasses)
+//            let gesture = UITapGestureRecognizer(target: self, action: #selector(self.dropClasses(sender:) ))
+//            header.addGestureRecognizer(gesture)
+//        }
+//        return header
+//    }
 }

--- a/Uplift/Controllers/FilterViewController.swift
+++ b/Uplift/Controllers/FilterViewController.swift
@@ -147,16 +147,16 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
         contentView.addSubview(startTimeClassTypeDivider)
 
         // CLASS TYPE SECTION
-        classTypeDropdownHeader = DropdownHeaderView(frame: .zero, title: ClientStrings.Filter.selectClassTypeSection)
+        classTypeDropdownHeader = DropdownHeaderView(title: ClientStrings.Filter.selectClassTypeSection)
         contentView.addSubview(classTypeDropdownHeader)
-        
-        classTypeDropdownFooter = DropdownFooterView(frame: .zero)
+
+        classTypeDropdownFooter = DropdownFooterView()
         classTypeDropdownFooter.clipsToBounds = true
         contentView.addSubview(classTypeDropdownFooter)
-        
+
         let toggleMoreClasses = UITapGestureRecognizer(target: self, action: #selector(self.dropHideClasses(sender:) ))
         classTypeDropdownFooter.addGestureRecognizer(toggleMoreClasses)
-        
+
         classTypeDropdown = UITableView()
         classTypeDropdown.separatorStyle = .none
         classTypeDropdown.showsVerticalScrollIndicator = false
@@ -183,10 +183,10 @@ class FilterViewController: UIViewController, RangeSeekSliderDelegate {
         }
 
         // INSTRUCTOR SECTION
-        instructorDropdownHeader = DropdownHeaderView(frame: .zero, title: ClientStrings.Filter.selectInstructorSection)
+        instructorDropdownHeader = DropdownHeaderView(title: ClientStrings.Filter.selectInstructorSection)
         contentView.addSubview(instructorDropdownHeader)
         
-        instructorDropdownFooter = DropdownFooterView(frame: .zero)
+        instructorDropdownFooter = DropdownFooterView()
         instructorDropdownFooter.clipsToBounds = true
         contentView.addSubview(instructorDropdownFooter)
         

--- a/Uplift/Views/Dropdown/DropdownHeaderView.swift
+++ b/Uplift/Views/Dropdown/DropdownHeaderView.swift
@@ -13,21 +13,23 @@ protocol DropdownHeaderViewDelegate: class {
 }
 
 class DropdownHeaderView: UIView {
-    
-    var filtersAppliedCircle: UIView!
-    var selectedFiltersLabel: UILabel!
-    var titleLabel: UILabel!
-    
-    private let arrowHeight: CGFloat = 9
+
     private let arrowImageView = UIImageView()
+    private let filtersAppliedCircle: UIView = UIView()
+    private let selectedFiltersLabel: UILabel = UILabel()
+    private let titleLabel: UILabel = UILabel()
+
+    private let arrowHeight: CGFloat = 9
     private let arrowWidth: CGFloat = 5
     private var isArrowRotated = false
-    
+
     weak var delegate: DropdownHeaderViewDelegate?
     
     var filtersApplied: Bool = false {
         didSet {
-            self.filtersAppliedCircle.layer.backgroundColor = filtersApplied ? UIColor.primaryYellow.cgColor : UIColor.primaryWhite.cgColor
+            self.filtersAppliedCircle.layer.backgroundColor = filtersApplied
+                ? UIColor.primaryYellow.cgColor
+                : UIColor.primaryWhite.cgColor
         }
     }
     var selectedFilters: [String] = [] {
@@ -36,22 +38,20 @@ class DropdownHeaderView: UIView {
         }
     }
 
-    init(frame: CGRect, arrowImage: UIImage? = nil, arrowImageTrailingOffset: CGFloat = -24) {
+    init(frame: CGRect, title: String, arrowImage: UIImage? = nil, arrowImageTrailingOffset: CGFloat = -24) {
         super.init(frame: frame)
 
         isUserInteractionEnabled = true
         
-        titleLabel = UILabel()
+        titleLabel.text = title
         titleLabel.font = ._12MontserratBold
         titleLabel.textColor = .gray04
         titleLabel.sizeToFit()
         addSubview(titleLabel)
 
-        filtersAppliedCircle = UIView()
         filtersAppliedCircle.layer.cornerRadius = 4
         addSubview(filtersAppliedCircle)
 
-        selectedFiltersLabel = UILabel()
         selectedFiltersLabel.textAlignment = .right
         selectedFiltersLabel.font = UIFont._14MontserratRegular
         selectedFiltersLabel.textColor = .primaryBlack
@@ -76,7 +76,7 @@ class DropdownHeaderView: UIView {
         let openCloseDropdownGesture = UITapGestureRecognizer(target: self, action: #selector(didTapView))
         addGestureRecognizer(openCloseDropdownGesture)
         
-        titleLabel.snp.updateConstraints { make in
+        titleLabel.snp.makeConstraints { make in
             make.left.equalToSuperview().offset(16)
             make.centerY.equalToSuperview()
         }
@@ -88,9 +88,9 @@ class DropdownHeaderView: UIView {
         }
         
         selectedFiltersLabel.snp.makeConstraints { make in
-               make.trailing.equalTo(arrowImageView.snp.leading).offset(-12)
-               make.centerY.equalTo(filtersAppliedCircle)
-        make.leading.equalTo(self.snp.centerX)
+            make.trailing.equalTo(arrowImageView.snp.leading).offset(-12)
+            make.centerY.equalTo(filtersAppliedCircle)
+            make.leading.equalTo(self.snp.centerX)
            }
     }
     

--- a/Uplift/Views/Dropdown/DropdownHeaderView.swift
+++ b/Uplift/Views/Dropdown/DropdownHeaderView.swift
@@ -38,8 +38,8 @@ class DropdownHeaderView: UIView {
         }
     }
 
-    init(frame: CGRect, title: String, arrowImage: UIImage? = nil, arrowImageTrailingOffset: CGFloat = -24) {
-        super.init(frame: frame)
+    init(title: String, arrowImage: UIImage? = nil, arrowImageTrailingOffset: CGFloat = -24) {
+        super.init(frame: .zero)
 
         isUserInteractionEnabled = true
         

--- a/Uplift/Views/Dropdown/DropdownHeaderView.swift
+++ b/Uplift/Views/Dropdown/DropdownHeaderView.swift
@@ -13,8 +13,6 @@ protocol DropdownHeaderViewDelegate: class {
 }
 
 class DropdownHeaderView: UIView {
-
-    static let identifier = Identifiers.dropdownViewCell
     
     var titleLabel: UILabel!
     

--- a/Uplift/Views/Dropdown/DropdownHeaderView.swift
+++ b/Uplift/Views/Dropdown/DropdownHeaderView.swift
@@ -40,16 +40,19 @@ class DropdownHeaderView: UIView {
             make.left.equalToSuperview().offset(16)
             make.centerY.equalToSuperview()
         }
-
+        
         if let image = arrowImage {
-            addSubview(arrowImageView)
             arrowImageView.image = image
-            arrowImageView.snp.makeConstraints { make in
-                make.centerY.equalToSuperview()
-                make.trailing.equalToSuperview().offset(arrowImageTrailingOffset)
-                make.height.equalTo(arrowHeight)
-                make.width.equalTo(arrowWidth)
-            }
+        } else {
+            // Default dropdown arrow.
+            arrowImageView.image = UIImage(named: ImageNames.rightArrow)
+        }
+        addSubview(arrowImageView)
+        arrowImageView.snp.makeConstraints { make in
+            make.centerY.equalToSuperview()
+            make.trailing.equalToSuperview().offset(arrowImageTrailingOffset)
+            make.height.equalTo(arrowHeight)
+            make.width.equalTo(arrowWidth)
         }
 
         let openCloseDropdownGesture = UITapGestureRecognizer(target: self, action: #selector(didTapView))

--- a/Uplift/Views/Dropdown/DropdownHeaderView.swift
+++ b/Uplift/Views/Dropdown/DropdownHeaderView.swift
@@ -14,6 +14,10 @@ protocol DropdownHeaderViewDelegate: class {
 
 class DropdownHeaderView: UIView {
 
+    static let identifier = Identifiers.dropdownViewCell
+    
+    var titleLabel: UILabel!
+    
     private let arrowHeight: CGFloat = 9
     private let arrowImageView = UIImageView()
     private let arrowWidth: CGFloat = 5
@@ -25,6 +29,17 @@ class DropdownHeaderView: UIView {
         super.init(frame: frame)
 
         isUserInteractionEnabled = true
+        
+        titleLabel = UILabel()
+        titleLabel.font = ._12MontserratBold
+        titleLabel.textColor = .gray04
+        titleLabel.sizeToFit()
+        addSubview(titleLabel)
+        
+        titleLabel.snp.updateConstraints { make in
+            make.left.equalToSuperview().offset(16)
+            make.centerY.equalToSuperview()
+        }
 
         if let image = arrowImage {
             addSubview(arrowImageView)

--- a/Uplift/Views/Dropdown/DropdownHeaderView.swift
+++ b/Uplift/Views/Dropdown/DropdownHeaderView.swift
@@ -14,14 +14,27 @@ protocol DropdownHeaderViewDelegate: class {
 
 class DropdownHeaderView: UIView {
     
+    var filtersAppliedCircle: UIView!
+    var selectedFiltersLabel: UILabel!
     var titleLabel: UILabel!
     
     private let arrowHeight: CGFloat = 9
     private let arrowImageView = UIImageView()
     private let arrowWidth: CGFloat = 5
     private var isArrowRotated = false
-
+    
     weak var delegate: DropdownHeaderViewDelegate?
+    
+    var filtersApplied: Bool = false {
+        didSet {
+            self.filtersAppliedCircle.layer.backgroundColor = filtersApplied ? UIColor.primaryYellow.cgColor : UIColor.primaryWhite.cgColor
+        }
+    }
+    var selectedFilters: [String] = [] {
+        didSet {
+            selectedFiltersLabel.text = selectedFilters.joined(separator: "  ·  ")
+        }
+    }
 
     init(frame: CGRect, arrowImage: UIImage? = nil, arrowImageTrailingOffset: CGFloat = -24) {
         super.init(frame: frame)
@@ -33,11 +46,18 @@ class DropdownHeaderView: UIView {
         titleLabel.textColor = .gray04
         titleLabel.sizeToFit()
         addSubview(titleLabel)
-        
-        titleLabel.snp.updateConstraints { make in
-            make.left.equalToSuperview().offset(16)
-            make.centerY.equalToSuperview()
-        }
+
+        filtersAppliedCircle = UIView()
+        filtersAppliedCircle.layer.cornerRadius = 4
+        addSubview(filtersAppliedCircle)
+
+        selectedFiltersLabel = UILabel()
+        selectedFiltersLabel.textAlignment = .right
+        selectedFiltersLabel.font = UIFont._14MontserratRegular
+        selectedFiltersLabel.textColor = .primaryBlack
+        selectedFiltersLabel.adjustsFontSizeToFitWidth = false
+        selectedFiltersLabel.lineBreakMode = NSLineBreakMode.byTruncatingTail
+        addSubview(selectedFiltersLabel)
         
         if let image = arrowImage {
             arrowImageView.image = image
@@ -55,6 +75,28 @@ class DropdownHeaderView: UIView {
 
         let openCloseDropdownGesture = UITapGestureRecognizer(target: self, action: #selector(didTapView))
         addGestureRecognizer(openCloseDropdownGesture)
+        
+        titleLabel.snp.updateConstraints { make in
+            make.left.equalToSuperview().offset(16)
+            make.centerY.equalToSuperview()
+        }
+        
+        filtersAppliedCircle.snp.makeConstraints { make in
+            make.height.width.equalTo(8)
+            make.leading.equalTo(titleLabel.snp.trailing).offset(12)
+            make.centerY.equalTo(titleLabel)
+        }
+        
+        selectedFiltersLabel.snp.makeConstraints { make in
+               make.trailing.equalTo(arrowImageView.snp.leading).offset(-12)
+               make.centerY.equalTo(filtersAppliedCircle)
+        make.leading.equalTo(self.snp.centerX)
+           }
+    }
+    
+    func updateDropdownHeader(selectedFilters: [String]) {
+        self.filtersApplied = !selectedFilters.isEmpty
+        self.selectedFilters = selectedFilters
     }
 
     required init?(coder: NSCoder) {

--- a/Uplift/Views/FacilitiesDropdownHeaderView.swift
+++ b/Uplift/Views/FacilitiesDropdownHeaderView.swift
@@ -14,7 +14,7 @@ class FacilitiesDropdownHeaderView: DropdownHeaderView {
     private let headerOpenLabel = UILabel()
 
     init(frame: CGRect) {
-        super.init(frame: frame, title: "", arrowImage: UIImage(named: ImageNames.rightArrowSolid))
+        super.init(title: "", arrowImage: UIImage(named: ImageNames.rightArrowSolid))
     }
 
     required init?(coder: NSCoder) {

--- a/Uplift/Views/FacilitiesDropdownHeaderView.swift
+++ b/Uplift/Views/FacilitiesDropdownHeaderView.swift
@@ -14,7 +14,7 @@ class FacilitiesDropdownHeaderView: DropdownHeaderView {
     private let headerOpenLabel = UILabel()
 
     init(frame: CGRect) {
-        super.init(frame: frame, arrowImage: UIImage(named: ImageNames.rightArrowSolid))
+        super.init(frame: frame, title: "", arrowImage: UIImage(named: ImageNames.rightArrowSolid))
     }
 
     required init?(coder: NSCoder) {

--- a/Uplift/Views/Footers/DropdownFooterView.swift
+++ b/Uplift/Views/Footers/DropdownFooterView.swift
@@ -16,7 +16,7 @@ class DropdownFooterView: UIView {
     var showHideLabel: UILabel!
     
     override init(frame: CGRect) {
-        super.init(frame: frame)
+        super.init(frame: .zero)
         
         isUserInteractionEnabled = true
         

--- a/Uplift/Views/Footers/DropdownFooterView.swift
+++ b/Uplift/Views/Footers/DropdownFooterView.swift
@@ -27,15 +27,15 @@ class DropdownFooterView: UIView {
         addSubview(showHideLabel)
         setupConstraints()
     }
-    
+
     func setupConstraints() {
         showHideLabel.snp.updateConstraints { make in
             make.bottom.equalToSuperview().offset(-16)
             make.left.equalToSuperview().offset(16)
         }
     }
-    
+
     required init?(coder: NSCoder) {
-           fatalError("init(coder:) has not been implemented")
+        fatalError("init(coder:) has not been implemented")
     }
 }

--- a/Uplift/Views/Footers/DropdownFooterView.swift
+++ b/Uplift/Views/Footers/DropdownFooterView.swift
@@ -9,37 +9,33 @@
 import SnapKit
 import UIKit
 
-class DropdownFooterView: UITableViewHeaderFooterView {
+class DropdownFooterView: UIView {
 
     // MARK: - INITIALIZATION
     static let identifier = Identifiers.dropdownFooterView
     var showHideLabel: UILabel!
-
-    override init(reuseIdentifier: String?) {
-        super.init(reuseIdentifier: reuseIdentifier)
-        layer.backgroundColor = UIColor.white.cgColor
-
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        isUserInteractionEnabled = true
+        
         showHideLabel = UILabel()
         showHideLabel.font = ._12MontserratMedium
         showHideLabel.sizeToFit()
         showHideLabel.textColor = .gray02
-        contentView.addSubview(showHideLabel)
-    }
-
-    required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    // MARK: - CONSTRAINTS
-    override open func layoutSubviews() {
-        super.layoutSubviews()
+        addSubview(showHideLabel)
         setupConstraints()
     }
-
+    
     func setupConstraints() {
         showHideLabel.snp.updateConstraints { make in
             make.bottom.equalToSuperview().offset(-16)
             make.left.equalToSuperview().offset(16)
         }
+    }
+    
+    required init?(coder: NSCoder) {
+           fatalError("init(coder:) has not been implemented")
     }
 }


### PR DESCRIPTION
## Overview
Replace old tableview headers/footers with new UIView dropdown headers and footers for the Filter View Controller.

## Test Coverage
Compiles and runs. Headers/footers work the same as what was on Uplift.

## Next Steps (delete if not applicable)
1. Replace gym hours and equipment dropdowns with same dropdown header

## Related PRs or Issues (delete if not applicable)
#232 