### PR TITLE
Update the home page cells

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -23,9 +23,13 @@ force_cast: warning # implicitly. Give warning only for force casting
 force_try:
 severity: warning # explicitly. Give warning only for force try
 
+function_body_length:
+- 100 # warning
+- 120 # error
+
 type_body_length:
 - 300 # warning
-- 400 # error
+- 500 # error
 
 # or they can set both explicitly
 file_length:

--- a/Uplift/Controllers/HomeViewController+Extensions.swift
+++ b/Uplift/Controllers/HomeViewController+Extensions.swift
@@ -84,7 +84,7 @@ extension HomeViewController: UICollectionViewDelegate, UICollectionViewDelegate
         case .todaysClasses:
             let padding: CGFloat = 20.0
             let cellWidth = gymClassInstances.isEmpty ? width - 2.0 * padding : width
-            return CGSize(width: cellWidth, height: 227)
+            return CGSize(width: cellWidth, height: TodaysClassesListCell.totalHeight)
         case .yourActivities:
             let height = ActivitiesListCell.itemHeight
             return CGSize(width: width, height: height)
@@ -93,11 +93,11 @@ extension HomeViewController: UICollectionViewDelegate, UICollectionViewDelegate
 
             //Height of all cells (in rows of 2), plus line spacings after each of them
             //MARK: myGyms gyms.count and removed / 2
-            var height: CGFloat = (GymsListCell.itemHeight + GymsListCell.minimumLineSpacing) * ceil(CGFloat(integerLiteral: gyms.count))
+            var height: CGFloat = (GymsListCell.itemHeight + GymsListCell.minimumItemSpacing) * ceil(CGFloat(integerLiteral: gyms.count))
 
             //Subtract extra minimum line spacing below the last row of cells, and add the section inset
-            height += GymsListCell.sectionInsetBottom - GymsListCell.minimumLineSpacing
-            return CGSize(width: width, height: height)
+            height += GymsListCell.sectionInsetBottom - GymsListCell.minimumItemSpacing
+            return CGSize(width: width, height: max(height, 0))
         }
     }
 

--- a/Uplift/Controllers/HomeViewController.swift
+++ b/Uplift/Controllers/HomeViewController.swift
@@ -53,6 +53,7 @@ class HomeViewController: UIViewController {
 
         // MARK: removed .lookingFor
         sections = [.todaysClasses, .yourActivities, .myGyms]
+        
         activities = [Activity(name: "Lifting", image: ActivitiesImages.lifting),
                   Activity(name: "Basketball", image: ActivitiesImages.basketball),
                   Activity(name: "Bowling", image: ActivitiesImages.bowling),
@@ -146,7 +147,7 @@ extension HomeViewController {
         collectionView.delaysContentTouches = false
         collectionView.showsVerticalScrollIndicator = false
         collectionView.layer.zPosition = -1
-
+        
         collectionView.register(HomeSectionHeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: HomeSectionHeaderView.identifier)
         collectionView.register(TodaysClassesListCell.self, forCellWithReuseIdentifier: Constants.todaysClassesListCellIdentifier)
         collectionView.register(TodaysClassesEmptyCell.self, forCellWithReuseIdentifier: Constants.todaysClassesEmptyCellIdentifier)

--- a/Uplift/Controllers/HomeViewController.swift
+++ b/Uplift/Controllers/HomeViewController.swift
@@ -89,6 +89,13 @@ class HomeViewController: UIViewController {
             self.collectionView.reloadSections(IndexSet(integer: 0))
             self.decrementNumPendingNetworkRequests()
         })
+        
+//        var testGym1 = GymClassInstance(classDescription: "Testinggg", classDetailId: "ASDF", className: "asdfasdf", duration: 60, endTime: Date(timeIntervalSinceNow: TimeInterval(integerLiteral: 60)), gymId: "ud", imageURL: URL(string: "asdf")!, instructor: "Instructio", isCancelled: true, location: "Noyes", startTime: Date(timeIntervalSinceNow: TimeInterval(integerLiteral: 0)), tags: [])
+//        
+//        var testGym2 = GymClassInstance(classDescription: "Testinggg", classDetailId: "ASDF", className: "asdfasdf", duration: 60, endTime: Date(timeIntervalSinceNow: TimeInterval(integerLiteral: 60)), gymId: "ud", imageURL: URL(string: "asdf")!, instructor: "Instructio", isCancelled: false, location: "Noyes", startTime: Date(timeIntervalSinceNow: TimeInterval(integerLiteral: 0)), tags: [])
+//        
+//        var testGym3 = GymClassInstance(classDescription: "Testinggg", classDetailId: "ASDF", className: "asdfasdf", duration: 60, endTime: Date(timeIntervalSinceNow: TimeInterval(integerLiteral: 60)), gymId: "ud", imageURL: URL(string: "asdf")!, instructor: "Instructio", isCancelled: false, location: "Noyes", startTime: Date(timeIntervalSinceNow: TimeInterval(integerLiteral: 0)), tags: [])
+//        self.gymClassInstances = [testGym1, testGym2, testGym3]
 
         presentAnnouncement(completion: nil)
     }

--- a/Uplift/Controllers/HomeViewController.swift
+++ b/Uplift/Controllers/HomeViewController.swift
@@ -53,7 +53,6 @@ class HomeViewController: UIViewController {
 
         // MARK: removed .lookingFor
         sections = [.todaysClasses, .yourActivities, .myGyms]
-
         activities = [Activity(name: "Lifting", image: ActivitiesImages.lifting),
                   Activity(name: "Basketball", image: ActivitiesImages.basketball),
                   Activity(name: "Bowling", image: ActivitiesImages.bowling),
@@ -89,6 +88,9 @@ class HomeViewController: UIViewController {
             self.collectionView.reloadSections(IndexSet(integer: 0))
             self.decrementNumPendingNetworkRequests()
         })
+        
+        
+        // These are dummy test data for dev and to test cancelled classes
         
 //        var testGym1 = GymClassInstance(classDescription: "Testinggg", classDetailId: "ASDF", className: "asdfasdf", duration: 60, endTime: Date(timeIntervalSinceNow: TimeInterval(integerLiteral: 60)), gymId: "ud", imageURL: URL(string: "asdf")!, instructor: "Instructio", isCancelled: true, location: "Noyes", startTime: Date(timeIntervalSinceNow: TimeInterval(integerLiteral: 0)), tags: [])
 //        

--- a/Uplift/Controllers/HomeViewController.swift
+++ b/Uplift/Controllers/HomeViewController.swift
@@ -51,15 +51,15 @@ class HomeViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        //MARK: removed .lookingFor
+        // MARK: removed .lookingFor
         sections = [.todaysClasses, .yourActivities, .myGyms]
 
-        activities = [Activity(name:"Lifting", image: activitiesImages.lifting),
-                  Activity(name:"Basketball", image: activitiesImages.basketball),
-                  Activity(name:"Bowling", image: activitiesImages.bowling),
-                  Activity(name:"Swimming", image: activitiesImages.swimming),
-                  Activity(name:"Lifting", image: activitiesImages.lifting),
-                  Activity(name:"Basketball", image: activitiesImages.basketball)]
+        activities = [Activity(name: "Lifting", image: ActivitiesImages.lifting),
+                  Activity(name: "Basketball", image: ActivitiesImages.basketball),
+                  Activity(name: "Bowling", image: ActivitiesImages.bowling),
+                  Activity(name: "Swimming", image: ActivitiesImages.swimming),
+                  Activity(name: "Lifting", image: ActivitiesImages.lifting),
+                  Activity(name: "Basketball", image: ActivitiesImages.basketball)]
 
         view.backgroundColor = UIColor.primaryWhite
 
@@ -137,13 +137,13 @@ extension HomeViewController {
         collectionView.delaysContentTouches = false
         collectionView.showsVerticalScrollIndicator = false
         collectionView.layer.zPosition = -1
-        
+
         collectionView.register(HomeSectionHeaderView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: HomeSectionHeaderView.identifier)
         collectionView.register(TodaysClassesListCell.self, forCellWithReuseIdentifier: Constants.todaysClassesListCellIdentifier)
         collectionView.register(TodaysClassesEmptyCell.self, forCellWithReuseIdentifier: Constants.todaysClassesEmptyCellIdentifier)
         collectionView.register(ActivitiesListCell.self, forCellWithReuseIdentifier: Constants.activitiesListCellIdentifier)
         collectionView.register(GymsListCell.self, forCellWithReuseIdentifier: Constants.gymsListCellIdentifier)
-        
+
         view.addSubview(collectionView)
 
         view.addSubview(loadingHeader)

--- a/Uplift/Supporting/Constants.swift
+++ b/Uplift/Supporting/Constants.swift
@@ -213,7 +213,7 @@ struct ImageNames {
 }
 
 // MARK: - SPORTS IMAGES
-struct activitiesImages {
+struct ActivitiesImages {
     // ACTIVITIES IMAGES
     static let lifting = UIImage(named: "lifting")!
     static let basketball = UIImage(named: "basketball1")!

--- a/Uplift/Views/Footers/GymCellFooter.swift
+++ b/Uplift/Views/Footers/GymCellFooter.swift
@@ -41,6 +41,7 @@ class GymCellFooter: UIView {
         hoursLabel.text = getHoursString(from: gym)
 
         capacityStatusLabel.text = "Cramped"
+        capacityStatusLabel.textColor = .accentOrange
         capacityCountLabel.text = "120/140"
     }
 
@@ -101,8 +102,9 @@ class GymCellFooter: UIView {
         let leadingPadding = 16
         let locationLabelHeight = 22
         let topBottomLabelVerticalPadding = 8
+        let statusLabelTopPadding = 4
         let statusHoursLabelPadding = 4
-        let statusLabelTopPadding = 1
+        let capacityTopPadding = 2
         let trailingPadding = 4
 
         locationNameLabel.snp.updateConstraints { make in
@@ -116,7 +118,7 @@ class GymCellFooter: UIView {
             make.leading.equalTo(locationNameLabel)
             make.trailing.lessThanOrEqualToSuperview().inset(trailingPadding)
             make.height.equalTo(descriptionLabelHeight)
-            make.bottom.equalToSuperview().offset(-topBottomLabelVerticalPadding)
+            make.top.equalTo(locationNameLabel.snp.bottom).offset(statusLabelTopPadding)
         }
 
         hoursLabel.snp.updateConstraints { make in
@@ -126,23 +128,19 @@ class GymCellFooter: UIView {
             make.centerY.equalTo(statusLabel.snp.centerY)
         }
 
-//MARK: To be implemented when backend get's their networking done
-
-/*
          capacityStatusLabel.snp.updateConstraints { make in
              make.leading.equalTo(locationNameLabel)
              make.trailing.lessThanOrEqualToSuperview().inset(trailingPadding)
              make.height.equalTo(statusLabel)
-             make.bottom.equalTo(capacityCountLabel.snp.bottom)
+             make.top.equalTo(statusLabel.snp.bottom).offset(capacityTopPadding)
          }
 
          capacityCountLabel.snp.updateConstraints { make in
              make.leading.equalTo(capacityStatusLabel.snp.trailing).offset(statusHoursLabelPadding)
-             make.height.equalTo(statusLabel)
+             make.height.equalTo(capacityStatusLabel)
              make.trailing.lessThanOrEqualToSuperview().inset(trailingPadding)
-             make.bottom.equalToSuperview().offset(-topBottomLabelVerticalPadding)
+             make.top.equalTo(capacityStatusLabel)
          }
- */
 
     }
 

--- a/Uplift/Views/GymDetail/Facilities/EquipmentListCell.swift
+++ b/Uplift/Views/GymDetail/Facilities/EquipmentListCell.swift
@@ -30,8 +30,7 @@ class EquipmentListCell: ListCollectionViewCell<EquipmentCategory, EquipmentList
 
         return ListConfiguration(
             itemSize: CGSize(width: 247.0, height: maxCellHeight),
-            minimumInteritemSpacing: 16,
-            minimumLineSpacing: 16,
+            minimumItemSpacing: 16,
             sectionInset: UIEdgeInsets(top: EquipmentListCell.topBottomInset, left: 24.0, bottom: EquipmentListCell.topBottomInset, right: 24.0)
         )
     }

--- a/Uplift/Views/Home/ActivitiesListCell.swift
+++ b/Uplift/Views/Home/ActivitiesListCell.swift
@@ -13,8 +13,7 @@ class ActivitiesListCell: ListCollectionViewCell<Activity, ActivityListItemCell>
 
     // MARK: - Public data vars
     static let itemHeight: CGFloat = 110.0
-    static let minimumInterItemSpacing: CGFloat = 16.0
-    static let minimumLineSpacing: CGFloat = 16.0
+    static let minimumItemSpacing: CGFloat = 16.0
     static let sectionInsetBottom: CGFloat = 32.0
     static let sectionInsetLeft: CGFloat = 12.0
     static let sectionInsetRight: CGFloat = 12.0
@@ -23,7 +22,7 @@ class ActivitiesListCell: ListCollectionViewCell<Activity, ActivityListItemCell>
     override var config: ListConfiguration {
         return ListConfiguration(
             itemSize: CGSize(width: 80, height: ActivitiesListCell.itemHeight),
-            minimumInteritemSpacing: ActivitiesListCell.minimumInterItemSpacing,
+            minimumItemSpacing: ActivitiesListCell.minimumItemSpacing,
             sectionInset: UIEdgeInsets(top: 0.0, left: 12.0, bottom: 32.0, right: 12.0)
         )
     }

--- a/Uplift/Views/Home/ActivityListItemCell.swift
+++ b/Uplift/Views/Home/ActivityListItemCell.swift
@@ -43,6 +43,7 @@ class ActivityListItemCell: ListItemCollectionViewCell<Activity> {
         activityImageView.layer.shadowOffset = CGSize(width: 1, height: 2)
         activityImageView.layer.shadowRadius = imageViewshadowRadius
         activityImageView.contentMode = .scaleAspectFit
+
         contentView.addSubview(activityImageView)
 
         activityLabel.textAlignment = .center

--- a/Uplift/Views/Home/GymListItemCell.swift
+++ b/Uplift/Views/Home/GymListItemCell.swift
@@ -15,10 +15,6 @@ class GymListItemCell: ListItemCollectionViewCell<Gym> {
     static let identifier = Identifiers.gymsCell
 
     // MARK: - Private view vars
-    private let hoursLabel = UILabel()
-    private let locationNameLabel = UILabel()
-    private let shadowView = UIView()
-    private let statusLabel = UILabel()
     private let backgroundImage = UIImageView()
     private let gymCellFooter = GymCellFooter()
 

--- a/Uplift/Views/Home/GymListItemCell.swift
+++ b/Uplift/Views/Home/GymListItemCell.swift
@@ -56,7 +56,7 @@ class GymListItemCell: ListItemCollectionViewCell<Gym> {
     }
 
     private func setupConstraints() {
-        let footerHeight = 55
+        let footerHeight = 75
 
         backgroundImage.snp.makeConstraints { make in
             make.edges.equalToSuperview()

--- a/Uplift/Views/Home/GymsListCell.swift
+++ b/Uplift/Views/Home/GymsListCell.swift
@@ -16,7 +16,7 @@ class GymsListCell: ListCollectionViewCell<Gym, GymListItemCell> {
 
     // MARK: - Public data vars
     weak var delegate: GymsListCellDelegate?
-    static let itemHeight: CGFloat = 180.0
+    static let itemHeight: CGFloat = 190.0
     
     static let minimumItemSpacing: CGFloat = 30.0
     

--- a/Uplift/Views/Home/GymsListCell.swift
+++ b/Uplift/Views/Home/GymsListCell.swift
@@ -17,20 +17,20 @@ class GymsListCell: ListCollectionViewCell<Gym, GymListItemCell> {
     // MARK: - Public data vars
     weak var delegate: GymsListCellDelegate?
     static let itemHeight: CGFloat = 180.0
-    static let minimumInterItemSpacing: CGFloat = 16.0
-    static let minimumLineSpacing: CGFloat = 16.0
+    
+    static let minimumItemSpacing: CGFloat = 30.0
+    
     static let sectionInsetBottom: CGFloat = 32.0
     static let sectionInsetLeft: CGFloat = 12.0
     static let sectionInsetRight: CGFloat = 12.0
 
     // MARK: - Overrides
     override var config: ListConfiguration {
-        let width: CGFloat = (self.bounds.width - GymsListCell.minimumInterItemSpacing - GymsListCell.sectionInsetLeft - GymsListCell.sectionInsetRight)
+        let width: CGFloat = (self.bounds.width - GymsListCell.sectionInsetLeft - GymsListCell.sectionInsetRight)
         return ListConfiguration(
             isScrollEnabled: true,
             itemSize: CGSize(width: width, height: GymsListCell.itemHeight),
-            minimumInteritemSpacing: GymsListCell.minimumInterItemSpacing,
-            minimumLineSpacing: GymsListCell.minimumLineSpacing,
+            minimumItemSpacing: GymsListCell.minimumItemSpacing,
             scrollDirection: .vertical,
             sectionInset: UIEdgeInsets(top: 0.0, left: GymsListCell.sectionInsetLeft, bottom: GymsListCell.sectionInsetBottom, right: GymsListCell.sectionInsetRight)
         )

--- a/Uplift/Views/Home/GymsListCell.swift
+++ b/Uplift/Views/Home/GymsListCell.swift
@@ -16,6 +16,7 @@ class GymsListCell: ListCollectionViewCell<Gym, GymListItemCell> {
 
     // MARK: - Public data vars
     weak var delegate: GymsListCellDelegate?
+    
     static let itemHeight: CGFloat = 190.0
     
     static let minimumItemSpacing: CGFloat = 30.0

--- a/Uplift/Views/Home/GymsListCell.swift
+++ b/Uplift/Views/Home/GymsListCell.swift
@@ -13,7 +13,7 @@ protocol GymsListCellDelegate: class {
 }
 
 class GymsListCell: ListCollectionViewCell<Gym, GymListItemCell> {
-    
+
     // MARK: - Public data vars
     weak var delegate: GymsListCellDelegate?
     static let itemHeight: CGFloat = 180.0

--- a/Uplift/Views/Home/LookingForListCell.swift
+++ b/Uplift/Views/Home/LookingForListCell.swift
@@ -24,17 +24,16 @@ class LookingForListCell: ListCollectionViewCell<Tag, LookingForListItemCell> {
         return (collectionViewWidth - 48) / 2
     }
     
-    static let minimumInterItemSpacing: CGFloat = 16
-    static let minimumLineSpacing: CGFloat = 16
     static let sectionInset = UIEdgeInsets(top: 0.0, left: 16.0, bottom: 32.0, right: 16.0)
 
+    static let minimumItemSpace: CGFloat = 16
+    
     // MARK: - Overrides
     override var config: ListConfiguration {
         return ListConfiguration(
             isScrollEnabled: false,
             itemSize: CGSize(width: self.width, height: self.height),
-            minimumInteritemSpacing: 16,
-            minimumLineSpacing: 16,
+            minimumItemSpacing: LookingForListCell.minimumItemSpace,
             scrollDirection: .vertical,
             sectionInset: UIEdgeInsets(top: 0.0, left: 16.0, bottom: 32.0, right: 16.0)
         )
@@ -63,6 +62,6 @@ class LookingForListCell: ListCollectionViewCell<Tag, LookingForListItemCell> {
     }
     
     static func getHeight(collectionViewWidth: CGFloat, numTags: Int) -> CGFloat {
-        return CGFloat(numTags / 2) * (((collectionViewWidth-48)/2)*0.78 + minimumInterItemSpacing)
+        return CGFloat(numTags / 2) * (((collectionViewWidth-48)/2)*0.78 + minimumItemSpace)
     }
 }

--- a/Uplift/Views/Home/TodaysClassListItemCell.swift
+++ b/Uplift/Views/Home/TodaysClassListItemCell.swift
@@ -54,7 +54,6 @@ class TodaysClassListItemCell: ListItemCollectionViewCell<GymClassInstance> {
         classNameLabel.text = item.className
         locationNameLabel.text = item.location
         hoursLabel.text = getHoursString(from: item)
-//        imageView.kf.setImage(with: item.imageURL)
 
         // Check if class is cancelled or not
         if item.isCancelled {

--- a/Uplift/Views/Home/TodaysClassListItemCell.swift
+++ b/Uplift/Views/Home/TodaysClassListItemCell.swift
@@ -18,10 +18,8 @@ class TodaysClassListItemCell: ListItemCollectionViewCell<GymClassInstance> {
     // MARK: - Private view vars
     private let cancelledLabel = UILabel()
     private let cancelledView = UIView()
-    
     private let classNameLabel = UILabel()
     private let hoursLabel = UILabel()
-//    private let imageView = UIImageView()
     private let locationWidget = UIImageView()
     private let locationNameLabel = UILabel()
 
@@ -77,12 +75,6 @@ class TodaysClassListItemCell: ListItemCollectionViewCell<GymClassInstance> {
     }
 
     private func setupViews() {
-//        imageView.clipsToBounds = true
-//        imageView.layer.cornerRadius = 5
-//        imageView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
-//        imageView.contentMode = .scaleAspectFill
-//        contentView.addSubview(imageView)
-
         cancelledView.backgroundColor = .accentClosed
         cancelledView.isHidden = true
         cancelledView.layer.cornerRadius = 5
@@ -114,20 +106,13 @@ class TodaysClassListItemCell: ListItemCollectionViewCell<GymClassInstance> {
 
     private func setupConstraints() {
         let cancelledViewSize = CGSize(width: 90, height: 27)
-//        let cancelledViewTopPadding = 17
         let classNameLabelHorizontalPadding = 21
         let classNameLabelTopPadding = 13
         let hoursLabelRightPadding = 21
-//        let imageViewHeight = 100
         let locationNameLabelLeftPadding = 5
         let locationNameLabelRightPadding = 21
         let locationWidgetBottomPadding = 14
         let locationWidgetSize = CGSize(width: 9, height: 13)
-
-//        imageView.snp.makeConstraints { make in
-//            make.leading.trailing.top.equalToSuperview()
-//            make.height.equalTo(imageViewHeight)
-//        }
 
         cancelledView.snp.makeConstraints { make in
             make.top.equalToSuperview()

--- a/Uplift/Views/Home/TodaysClassListItemCell.swift
+++ b/Uplift/Views/Home/TodaysClassListItemCell.swift
@@ -18,11 +18,12 @@ class TodaysClassListItemCell: ListItemCollectionViewCell<GymClassInstance> {
     // MARK: - Private view vars
     private let cancelledLabel = UILabel()
     private let cancelledView = UIView()
+    
     private let classNameLabel = UILabel()
     private let hoursLabel = UILabel()
-    private let imageView = UIImageView()
-    private let locationNameLabel = UILabel()
+//    private let imageView = UIImageView()
     private let locationWidget = UIImageView()
+    private let locationNameLabel = UILabel()
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -35,8 +36,8 @@ class TodaysClassListItemCell: ListItemCollectionViewCell<GymClassInstance> {
 
         // SHADOWING
         contentView.layer.shadowColor = UIColor.gray01.cgColor
-        contentView.layer.shadowOffset = CGSize(width: 0.0, height: 11.0)
-        contentView.layer.shadowRadius = 7.0
+        contentView.layer.shadowOffset = CGSize(width: 1.0, height: 2.0)
+        contentView.layer.shadowRadius = 5.0
         contentView.layer.shadowOpacity = 1.0
         contentView.layer.masksToBounds = false
 
@@ -54,15 +55,14 @@ class TodaysClassListItemCell: ListItemCollectionViewCell<GymClassInstance> {
     override func configure(for item: GymClassInstance) {
         classNameLabel.text = item.className
         locationNameLabel.text = item.location
-        imageView.kf.setImage(with: item.imageURL)
+        hoursLabel.text = getHoursString(from: item)
+//        imageView.kf.setImage(with: item.imageURL)
 
         // Check if class is cancelled or not
         if item.isCancelled {
             cancelledView.isHidden = false
             cancelledLabel.isHidden = false
             classNameLabel.textColor = .gray03
-        } else {
-            hoursLabel.text = getHoursString(from: item)
         }
     }
 
@@ -77,14 +77,15 @@ class TodaysClassListItemCell: ListItemCollectionViewCell<GymClassInstance> {
     }
 
     private func setupViews() {
-        imageView.clipsToBounds = true
-        imageView.layer.cornerRadius = 5
-        imageView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
-        imageView.contentMode = .scaleAspectFill
-        contentView.addSubview(imageView)
+//        imageView.clipsToBounds = true
+//        imageView.layer.cornerRadius = 5
+//        imageView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+//        imageView.contentMode = .scaleAspectFill
+//        contentView.addSubview(imageView)
 
         cancelledView.backgroundColor = .accentClosed
         cancelledView.isHidden = true
+        cancelledView.layer.cornerRadius = 5
         contentView.addSubview(cancelledView)
 
         cancelledLabel.text = ClientStrings.Home.todaysClassCancelled
@@ -112,25 +113,25 @@ class TodaysClassListItemCell: ListItemCollectionViewCell<GymClassInstance> {
     }
 
     private func setupConstraints() {
-        let cancelledViewSize = CGSize(width: 100, height: 32)
-        let cancelledViewTopPadding = 17
+        let cancelledViewSize = CGSize(width: 90, height: 27)
+//        let cancelledViewTopPadding = 17
         let classNameLabelHorizontalPadding = 21
         let classNameLabelTopPadding = 13
         let hoursLabelRightPadding = 21
-        let imageViewHeight = 100
+//        let imageViewHeight = 100
         let locationNameLabelLeftPadding = 5
         let locationNameLabelRightPadding = 21
         let locationWidgetBottomPadding = 14
         let locationWidgetSize = CGSize(width: 9, height: 13)
 
-        imageView.snp.makeConstraints { make in
-            make.leading.trailing.top.equalToSuperview()
-            make.height.equalTo(imageViewHeight)
-        }
+//        imageView.snp.makeConstraints { make in
+//            make.leading.trailing.top.equalToSuperview()
+//            make.height.equalTo(imageViewHeight)
+//        }
 
         cancelledView.snp.makeConstraints { make in
-            make.top.equalToSuperview().offset(cancelledViewTopPadding)
-            make.leading.equalToSuperview()
+            make.top.equalToSuperview()
+            make.trailing.equalToSuperview()
             make.size.equalTo(cancelledViewSize)
         }
 
@@ -141,7 +142,7 @@ class TodaysClassListItemCell: ListItemCollectionViewCell<GymClassInstance> {
 
         classNameLabel.snp.makeConstraints { make in
             make.leading.equalToSuperview().offset(classNameLabelHorizontalPadding)
-            make.top.equalTo(imageView.snp.bottom).offset(classNameLabelTopPadding)
+            make.top.equalToSuperview().offset(classNameLabelTopPadding)
             make.trailing.lessThanOrEqualToSuperview().inset(classNameLabelHorizontalPadding)
         }
 

--- a/Uplift/Views/Home/TodaysClassesListCell.swift
+++ b/Uplift/Views/Home/TodaysClassesListCell.swift
@@ -17,15 +17,13 @@ class TodaysClassesListCell: ListCollectionViewCell<GymClassInstance, TodaysClas
 
     // MARK: - Public data vars
     weak var delegate: TodaysClassesListCellDelegate?
-    
+
     static let itemWidth: CGFloat = 228.0
     static let itemHeight: CGFloat = 80.0
-        
-    static let minimumItemSpacing: CGFloat = 25
-    
+    static let minimumItemSpacing: CGFloat = 25.0
     static let sectionInsetBottom: CGFloat = 10.0
     static let sectionInsetLeftRight: CGFloat = 12.0
-    
+
     static var totalHeight: CGFloat {
         itemHeight + sectionInsetBottom
     }
@@ -34,7 +32,7 @@ class TodaysClassesListCell: ListCollectionViewCell<GymClassInstance, TodaysClas
     override var config: ListConfiguration {
         return ListConfiguration(
             itemSize: CGSize(width: TodaysClassesListCell.itemWidth, height: TodaysClassesListCell.itemHeight),
-            minimumItemSpacing:  TodaysClassesListCell.minimumItemSpacing,
+            minimumItemSpacing: TodaysClassesListCell.minimumItemSpacing,
             sectionInset: UIEdgeInsets(top: 0.0, left: TodaysClassesListCell.sectionInsetLeftRight, bottom: TodaysClassesListCell.sectionInsetBottom, right: TodaysClassesListCell.sectionInsetLeftRight)
         )
     }

--- a/Uplift/Views/Home/TodaysClassesListCell.swift
+++ b/Uplift/Views/Home/TodaysClassesListCell.swift
@@ -19,17 +19,22 @@ class TodaysClassesListCell: ListCollectionViewCell<GymClassInstance, TodaysClas
     weak var delegate: TodaysClassesListCellDelegate?
     
     static let itemWidth: CGFloat = 228.0
-    static let itemHeight: CGFloat = 195.0
-    static let minimumInterItemSpacing: CGFloat = 16.0
-    static let minimumLineSpacing: CGFloat = 16.0
-    static let sectionInsetBottom: CGFloat = 32.0
+    static let itemHeight: CGFloat = 80.0
+        
+    static let minimumItemSpacing: CGFloat = 25
+    
+    static let sectionInsetBottom: CGFloat = 10.0
     static let sectionInsetLeftRight: CGFloat = 12.0
+    
+    static var totalHeight: CGFloat {
+        itemHeight + sectionInsetBottom
+    }
 
     // MARK: - Overrides
     override var config: ListConfiguration {
         return ListConfiguration(
             itemSize: CGSize(width: TodaysClassesListCell.itemWidth, height: TodaysClassesListCell.itemHeight),
-            minimumInteritemSpacing: TodaysClassesListCell.minimumInterItemSpacing,
+            minimumItemSpacing:  TodaysClassesListCell.minimumItemSpacing,
             sectionInset: UIEdgeInsets(top: 0.0, left: TodaysClassesListCell.sectionInsetLeftRight, bottom: TodaysClassesListCell.sectionInsetBottom, right: TodaysClassesListCell.sectionInsetLeftRight)
         )
     }

--- a/Uplift/Views/ListCollectionViewCell.swift
+++ b/Uplift/Views/ListCollectionViewCell.swift
@@ -95,7 +95,6 @@ class ListCollectionViewCell<T, U: ListItemCollectionViewCell<T>>: UICollectionV
         self.models = models
         DispatchQueue.main.async {
             self.collectionView.reloadData()
-//            self.reloadConfig()
         }
     }
 

--- a/Uplift/Views/ListCollectionViewCell.swift
+++ b/Uplift/Views/ListCollectionViewCell.swift
@@ -16,8 +16,7 @@ class ListConfiguration {
     var delaysContentTouches: Bool!
     var isScrollEnabled: Bool!
     var itemSize: CGSize!
-    var minimumInteritemSpacing: CGFloat!
-    var minimumLineSpacing: CGFloat!
+    var minimumItemSpacing: CGFloat!
     var sectionInset: UIEdgeInsets!
     var scrollDirection: UICollectionView.ScrollDirection!
     var showsScrollIndicator: Bool!
@@ -26,8 +25,7 @@ class ListConfiguration {
          delaysContentTouches: Bool = false,
          isScrollEnabled: Bool = true,
          itemSize: CGSize = .zero,
-         minimumInteritemSpacing: CGFloat = 0,
-         minimumLineSpacing: CGFloat = 0,
+         minimumItemSpacing: CGFloat = 0,
          scrollDirection: UICollectionView.ScrollDirection = .horizontal,
          sectionInset: UIEdgeInsets = .zero,
          showsScrollIndicator: Bool = false) {
@@ -35,8 +33,7 @@ class ListConfiguration {
         self.delaysContentTouches = delaysContentTouches
         self.isScrollEnabled = isScrollEnabled
         self.itemSize = itemSize
-        self.minimumInteritemSpacing = minimumInteritemSpacing
-        self.minimumLineSpacing = minimumLineSpacing
+        self.minimumItemSpacing = minimumItemSpacing
         self.scrollDirection = scrollDirection
         self.sectionInset = sectionInset
         self.showsScrollIndicator = showsScrollIndicator
@@ -66,12 +63,7 @@ class ListCollectionViewCell<T, U: ListItemCollectionViewCell<T>>: UICollectionV
         super.init(frame: frame)
 
         layout.scrollDirection = config.scrollDirection
-        if config.scrollDirection == .vertical {
-            layout.minimumLineSpacing = config.minimumLineSpacing
-        } else {
-            layout.minimumInteritemSpacing = config.minimumInteritemSpacing
-            layout.minimumInteritemSpacing = 150
-        }
+        layout.minimumLineSpacing = config.minimumItemSpacing
         layout.itemSize = config.itemSize
         layout.sectionInset = config.sectionInset
 
@@ -103,6 +95,7 @@ class ListCollectionViewCell<T, U: ListItemCollectionViewCell<T>>: UICollectionV
         self.models = models
         DispatchQueue.main.async {
             self.collectionView.reloadData()
+//            self.reloadConfig()
         }
     }
 
@@ -142,11 +135,8 @@ class ListCollectionViewCell<T, U: ListItemCollectionViewCell<T>>: UICollectionV
 
     func reloadConfig() {
         layout.scrollDirection = config.scrollDirection
-        if config.scrollDirection == .vertical {
-            layout.minimumLineSpacing = config.minimumLineSpacing
-        } else {
-            layout.minimumInteritemSpacing = config.minimumInteritemSpacing
-        }
+        layout.minimumLineSpacing = config.minimumItemSpacing
+
         layout.itemSize = config.itemSize
         layout.sectionInset = config.sectionInset
 


### PR DESCRIPTION
## Overview

The goal of this is to update the home page cells to more accurately match the Figma.

## Changes Made

There are two cells that have the most updates, the classes cells and the gym cells. Both of which has very simple code changes to update the appearance. 

## Test Coverage

I tested on an iPhone 14 to make sure the views matched that of the Figma.

## Next Steps (delete if not applicable)

At the moment, the data in the view (specifically capacity) are hard coded as we are waiting on the backend. 

## Screenshots (delete if not applicable)


<details>

  <summary>Old</summary>

![Simulator Screen Shot - iPhone 14 - 2023-04-26 at 15 27 56](https://user-images.githubusercontent.com/16356639/234945088-2e98cde2-621c-463d-a48c-d9da162f183b.png)  

</details>

<details>

  <summary>New</summary>

![Simulator Screen Shot - iPhone 14 - 2023-04-27 at 13 31 13](https://user-images.githubusercontent.com/16356639/234945292-c35d92f4-75aa-4b5b-8d47-f5a0a4286785.png)

</details>