### PR TITLE
Update pods

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,5 +1,6 @@
 # Uncomment the next line to define a global platform for your project
-# platform :ios, '9.0'
+platform :ios, '11.0'
+
 
 target 'Uplift' do
   # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
@@ -9,26 +10,14 @@ target 'Uplift' do
   pod 'AppDevAnnouncements', :git => 'https://github.com/cuappdev/appdev-announcements.git'
   pod 'AppDevHistogram', :git => 'https://github.com/cuappdev/appdev-histogram.git'
   pod 'Bartinter'
-  pod 'Crashlytics'
-  pod 'FLEX', '~> 2.0', :configurations => ['Debug']
-  pod 'Fabric'
+  pod 'Crashlytics' 	# TODO: - remove
+  pod 'Fabric' 		# TODO: - remove
   pod 'Firebase/Analytics'
   pod 'GoogleSignIn'
-  pod 'Kingfisher', '~> 4.0'
-  pod 'Presentation', :git=> 'https://github.com/cuappdev/Presentation.git', :commit => 'd4aa2d3ad5901f6ebce0727af592824982f88d13'
+  pod 'Kingfisher'
+  pod 'Presentation', :git=> 'https://github.com/cuappdev/Presentation.git', :commit => 'b53eb453d2e1520e724cfac5e3e444e730ffe985'
   pod 'SideMenu', '~> 6.0'
   pod 'SkeletonView'
   pod 'SnapKit'
   pod 'SwiftLint'
-  #pod 'FadingEdgesCollectionView', :git=> 'https://github.com/cuappdev/FadingEdgesCollectionView'
-end
-
-post_install do |installer|
-  installer.pods_project.targets.each do |target|
-    if ['Alamofire', 'Bartinter', 'SnapKit'].include?(target.name)
-      target.build_configurations.each do |config|
-        config.build_settings['SWIFT_VERSION'] = '4.2'
-      end
-    end
-  end
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,109 +1,118 @@
 PODS:
-  - Alamofire (5.1.0)
-  - AlamofireImage (4.1.0):
-    - Alamofire (~> 5.1)
+  - Alamofire (5.7.1)
+  - AlamofireImage (4.2.0):
+    - Alamofire (~> 5.4)
   - Apollo (0.9.5):
     - Apollo/Core (= 0.9.5)
   - Apollo/Core (0.9.5)
-  - AppAuth (1.3.0):
-    - AppAuth/Core (= 1.3.0)
-    - AppAuth/ExternalUserAgent (= 1.3.0)
-  - AppAuth/Core (1.3.0)
-  - AppAuth/ExternalUserAgent (1.3.0)
+  - AppAuth (1.6.2):
+    - AppAuth/Core (= 1.6.2)
+    - AppAuth/ExternalUserAgent (= 1.6.2)
+  - AppAuth/Core (1.6.2)
+  - AppAuth/ExternalUserAgent (1.6.2):
+    - AppAuth/Core
   - AppDevAnnouncements (0.0.1)
-  - AppDevHistogram (1.0.0):
-    - SnapKit (~> 4.2.0)
+  - AppDevHistogram (1.0.1):
+    - SnapKit
   - Bartinter (0.0.5)
   - Crashlytics (3.14.0):
     - Fabric (~> 1.10.2)
   - Fabric (1.10.2)
-  - Firebase/Analytics (6.23.0):
+  - Firebase/Analytics (10.13.0):
     - Firebase/Core
-  - Firebase/Core (6.23.0):
+  - Firebase/Core (10.13.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (= 6.4.2)
-  - Firebase/CoreOnly (6.23.0):
-    - FirebaseCore (= 6.6.7)
-  - FirebaseAnalytics (6.4.2):
-    - FirebaseCore (~> 6.6)
-    - FirebaseInstallations (~> 1.2)
-    - GoogleAppMeasurement (= 6.4.2)
-    - GoogleUtilities/AppDelegateSwizzler (~> 6.0)
-    - GoogleUtilities/MethodSwizzler (~> 6.0)
-    - GoogleUtilities/Network (~> 6.0)
-    - "GoogleUtilities/NSData+zlib (~> 6.0)"
-    - nanopb (= 0.3.9011)
-  - FirebaseCore (6.6.7):
-    - FirebaseCoreDiagnostics (~> 1.2)
-    - FirebaseCoreDiagnosticsInterop (~> 1.2)
-    - GoogleUtilities/Environment (~> 6.5)
-    - GoogleUtilities/Logger (~> 6.5)
-  - FirebaseCoreDiagnostics (1.2.4):
-    - FirebaseCoreDiagnosticsInterop (~> 1.2)
-    - GoogleDataTransportCCTSupport (~> 3.0)
-    - GoogleUtilities/Environment (~> 6.5)
-    - GoogleUtilities/Logger (~> 6.5)
-    - nanopb (~> 0.3.901)
-  - FirebaseCoreDiagnosticsInterop (1.2.0)
-  - FirebaseInstallations (1.2.0):
-    - FirebaseCore (~> 6.6)
-    - GoogleUtilities/Environment (~> 6.6)
-    - GoogleUtilities/UserDefaults (~> 6.6)
-    - PromisesObjC (~> 1.2)
-  - FLEX (2.4.0)
-  - GoogleAppMeasurement (6.4.2):
-    - GoogleUtilities/AppDelegateSwizzler (~> 6.0)
-    - GoogleUtilities/MethodSwizzler (~> 6.0)
-    - GoogleUtilities/Network (~> 6.0)
-    - "GoogleUtilities/NSData+zlib (~> 6.0)"
-    - nanopb (= 0.3.9011)
-  - GoogleDataTransport (6.0.0)
-  - GoogleDataTransportCCTSupport (3.0.0):
-    - GoogleDataTransport (~> 6.0)
-    - nanopb (~> 0.3.901)
-  - GoogleSignIn (5.0.2):
-    - AppAuth (~> 1.2)
-    - GTMAppAuth (~> 1.0)
-    - GTMSessionFetcher/Core (~> 1.1)
-  - GoogleUtilities/AppDelegateSwizzler (6.6.0):
+    - FirebaseAnalytics (~> 10.13.0)
+  - Firebase/CoreOnly (10.13.0):
+    - FirebaseCore (= 10.13.0)
+  - FirebaseAnalytics (10.13.0):
+    - FirebaseAnalytics/AdIdSupport (= 10.13.0)
+    - FirebaseCore (~> 10.0)
+    - FirebaseInstallations (~> 10.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
+    - GoogleUtilities/MethodSwizzler (~> 7.11)
+    - GoogleUtilities/Network (~> 7.11)
+    - "GoogleUtilities/NSData+zlib (~> 7.11)"
+    - nanopb (< 2.30910.0, >= 2.30908.0)
+  - FirebaseAnalytics/AdIdSupport (10.13.0):
+    - FirebaseCore (~> 10.0)
+    - FirebaseInstallations (~> 10.0)
+    - GoogleAppMeasurement (= 10.13.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
+    - GoogleUtilities/MethodSwizzler (~> 7.11)
+    - GoogleUtilities/Network (~> 7.11)
+    - "GoogleUtilities/NSData+zlib (~> 7.11)"
+    - nanopb (< 2.30910.0, >= 2.30908.0)
+  - FirebaseCore (10.13.0):
+    - FirebaseCoreInternal (~> 10.0)
+    - GoogleUtilities/Environment (~> 7.8)
+    - GoogleUtilities/Logger (~> 7.8)
+  - FirebaseCoreInternal (10.13.0):
+    - "GoogleUtilities/NSData+zlib (~> 7.8)"
+  - FirebaseInstallations (10.13.0):
+    - FirebaseCore (~> 10.0)
+    - GoogleUtilities/Environment (~> 7.8)
+    - GoogleUtilities/UserDefaults (~> 7.8)
+    - PromisesObjC (~> 2.1)
+  - GoogleAppMeasurement (10.13.0):
+    - GoogleAppMeasurement/AdIdSupport (= 10.13.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
+    - GoogleUtilities/MethodSwizzler (~> 7.11)
+    - GoogleUtilities/Network (~> 7.11)
+    - "GoogleUtilities/NSData+zlib (~> 7.11)"
+    - nanopb (< 2.30910.0, >= 2.30908.0)
+  - GoogleAppMeasurement/AdIdSupport (10.13.0):
+    - GoogleAppMeasurement/WithoutAdIdSupport (= 10.13.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
+    - GoogleUtilities/MethodSwizzler (~> 7.11)
+    - GoogleUtilities/Network (~> 7.11)
+    - "GoogleUtilities/NSData+zlib (~> 7.11)"
+    - nanopb (< 2.30910.0, >= 2.30908.0)
+  - GoogleAppMeasurement/WithoutAdIdSupport (10.13.0):
+    - GoogleUtilities/AppDelegateSwizzler (~> 7.11)
+    - GoogleUtilities/MethodSwizzler (~> 7.11)
+    - GoogleUtilities/Network (~> 7.11)
+    - "GoogleUtilities/NSData+zlib (~> 7.11)"
+    - nanopb (< 2.30910.0, >= 2.30908.0)
+  - GoogleSignIn (7.0.0):
+    - AppAuth (~> 1.5)
+    - GTMAppAuth (< 3.0, >= 1.3)
+    - GTMSessionFetcher/Core (< 4.0, >= 1.1)
+  - GoogleUtilities/AppDelegateSwizzler (7.11.5):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (6.6.0):
-    - PromisesObjC (~> 1.2)
-  - GoogleUtilities/Logger (6.6.0):
+  - GoogleUtilities/Environment (7.11.5):
+    - PromisesObjC (< 3.0, >= 1.2)
+  - GoogleUtilities/Logger (7.11.5):
     - GoogleUtilities/Environment
-  - GoogleUtilities/MethodSwizzler (6.6.0):
+  - GoogleUtilities/MethodSwizzler (7.11.5):
     - GoogleUtilities/Logger
-  - GoogleUtilities/Network (6.6.0):
+  - GoogleUtilities/Network (7.11.5):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (6.6.0)"
-  - GoogleUtilities/Reachability (6.6.0):
+  - "GoogleUtilities/NSData+zlib (7.11.5)"
+  - GoogleUtilities/Reachability (7.11.5):
     - GoogleUtilities/Logger
-  - GoogleUtilities/UserDefaults (6.6.0):
+  - GoogleUtilities/UserDefaults (7.11.5):
     - GoogleUtilities/Logger
-  - GTMAppAuth (1.0.0):
-    - AppAuth/Core (~> 1.0)
-    - GTMSessionFetcher (~> 1.1)
-  - GTMSessionFetcher (1.3.1):
-    - GTMSessionFetcher/Full (= 1.3.1)
-  - GTMSessionFetcher/Core (1.3.1)
-  - GTMSessionFetcher/Full (1.3.1):
-    - GTMSessionFetcher/Core (= 1.3.1)
-  - Kingfisher (4.10.1)
-  - nanopb (0.3.9011):
-    - nanopb/decode (= 0.3.9011)
-    - nanopb/encode (= 0.3.9011)
-  - nanopb/decode (0.3.9011)
-  - nanopb/encode (0.3.9011)
-  - Presentation (4.2.3)
-  - PromisesObjC (1.2.8)
-  - SideMenu (6.4.8)
-  - SkeletonView (1.8.7)
-  - SnapKit (4.2.0)
-  - SwiftLint (0.39.2)
+  - GTMAppAuth (2.0.0):
+    - AppAuth/Core (~> 1.6)
+    - GTMSessionFetcher/Core (< 4.0, >= 1.5)
+  - GTMSessionFetcher/Core (3.1.1)
+  - Kingfisher (6.3.1)
+  - nanopb (2.30909.0):
+    - nanopb/decode (= 2.30909.0)
+    - nanopb/encode (= 2.30909.0)
+  - nanopb/decode (2.30909.0)
+  - nanopb/encode (2.30909.0)
+  - Presentation (4.2.4)
+  - PromisesObjC (2.3.1)
+  - SideMenu (6.5.0)
+  - SkeletonView (1.30.4)
+  - SnapKit (5.6.0)
+  - SwiftLint (0.52.4)
 
 DEPENDENCIES:
   - AlamofireImage
@@ -114,10 +123,9 @@ DEPENDENCIES:
   - Crashlytics
   - Fabric
   - Firebase/Analytics
-  - FLEX (~> 2.0)
   - GoogleSignIn
-  - Kingfisher (~> 4.0)
-  - Presentation (from `https://github.com/cuappdev/Presentation.git`, commit `d4aa2d3ad5901f6ebce0727af592824982f88d13`)
+  - Kingfisher
+  - Presentation (from `https://github.com/cuappdev/Presentation.git`, commit `b53eb453d2e1520e724cfac5e3e444e730ffe985`)
   - SideMenu (~> 6.0)
   - SkeletonView
   - SnapKit
@@ -134,13 +142,9 @@ SPEC REPOS:
     - Firebase
     - FirebaseAnalytics
     - FirebaseCore
-    - FirebaseCoreDiagnostics
-    - FirebaseCoreDiagnosticsInterop
+    - FirebaseCoreInternal
     - FirebaseInstallations
-    - FLEX
     - GoogleAppMeasurement
-    - GoogleDataTransport
-    - GoogleDataTransportCCTSupport
     - GoogleSignIn
     - GoogleUtilities
     - GTMAppAuth
@@ -162,7 +166,7 @@ EXTERNAL SOURCES:
   AppDevHistogram:
     :git: https://github.com/cuappdev/appdev-histogram.git
   Presentation:
-    :commit: d4aa2d3ad5901f6ebce0727af592824982f88d13
+    :commit: b53eb453d2e1520e724cfac5e3e444e730ffe985
     :git: https://github.com/cuappdev/Presentation.git
 
 CHECKOUT OPTIONS:
@@ -170,48 +174,44 @@ CHECKOUT OPTIONS:
     :commit: b28c3dc
     :git: https://github.com/apollographql/apollo-ios.git
   AppDevAnnouncements:
-    :commit: 4cfbcd46af092037ac6632fe5616a13e5f280615
+    :commit: ae01d4b73c8a5edc6c6c03b9c5670d016a5a63ef
     :git: https://github.com/cuappdev/appdev-announcements.git
   AppDevHistogram:
-    :commit: 8caf40987e10ccd055ded919809173d697c7f6ad
+    :commit: a0964fbf3c796ad9f2606643cf05ec092f27df7d
     :git: https://github.com/cuappdev/appdev-histogram.git
   Presentation:
-    :commit: d4aa2d3ad5901f6ebce0727af592824982f88d13
+    :commit: b53eb453d2e1520e724cfac5e3e444e730ffe985
     :git: https://github.com/cuappdev/Presentation.git
 
 SPEC CHECKSUMS:
-  Alamofire: 9d5c5f602928e512395b30950c5984eca840093c
-  AlamofireImage: c4a2ba349885fb3064feb74d2e547bd42ce9be10
+  Alamofire: 0123a34370cb170936ae79a8df46cc62b2edeb88
+  AlamofireImage: 34a2d90b0e5fe6a5605f85ae4b7b01e784c60192
   Apollo: 09002d68c46e4098766fe376151d9ff8bd6aad36
-  AppAuth: 73574f3013a1e65b9601a3ddc8b3158cce68c09d
+  AppAuth: 3bb1d1cd9340bd09f5ed189fb00b1cc28e1e8570
   AppDevAnnouncements: e17a7f441fb0664583bb08e21dc709214d15b70f
-  AppDevHistogram: 63293981a9c7a1144f17a0098725267abc415541
+  AppDevHistogram: e76c70f3bb75868a1fffed909133f54fa1611ffc
   Bartinter: 3c1fc3bcb631b066fdd78f7e01f1635fbafffdea
   Crashlytics: 9220f5bc89e7a618df411b4f639389dbfb0e03d2
   Fabric: ea977e3cd9c20425516d3dafd3bf8c941c51223f
-  Firebase: 585ae467b3edda6a5444e788fda6888f024d8d6f
-  FirebaseAnalytics: 558f7a03d19de451093032c806f39d5f9dff096e
-  FirebaseCore: a2788a0d5f6c1dff17b8f79b4a73654a8d4bfdbd
-  FirebaseCoreDiagnostics: b59c024493a409f8aecba02c99928d0d8431d159
-  FirebaseCoreDiagnosticsInterop: 296e2c5f5314500a850ad0b83e9e7c10b011a850
-  FirebaseInstallations: 2119fb3e46b0a88bfdbf12562f855ee3252462fa
-  FLEX: bd1a39e55b56bb413b6f1b34b3c10a0dc44ef079
-  GoogleAppMeasurement: 2253e99c1f22638cf234c059144660c338ad76c3
-  GoogleDataTransport: 061fe7d9b476710e3cd8ea51e8e07d8b67c2b420
-  GoogleDataTransportCCTSupport: 0f39025e8cf51f168711bd3fb773938d7e62ddb5
-  GoogleSignIn: 7137d297ddc022a7e0aa4619c86d72c909fa7213
-  GoogleUtilities: 39530bc0ad980530298e9c4af8549e991fd033b1
-  GTMAppAuth: 4deac854479704f348309e7b66189e604cf5e01e
-  GTMSessionFetcher: cea130bbfe5a7edc8d06d3f0d17288c32ffe9925
-  Kingfisher: c148cd7b47ebde9989f6bc7c27dcaa79d81279a0
-  nanopb: 18003b5e52dab79db540fe93fe9579f399bd1ccd
-  Presentation: 3c02ab6268b15e44b6146c511686eb9c3f81b7d0
-  PromisesObjC: c119f3cd559f50b7ae681fa59dc1acd19173b7e6
-  SideMenu: 4a891be552d30bb6fa87ad404d62e485f8450c34
-  SkeletonView: ba5370f41280b2f0a76918bb143c1294232bb4f4
-  SnapKit: fe8a619752f3f27075cc9a90244d75c6c3f27e2a
-  SwiftLint: 22ccbbe3b8008684be5955693bab135e0ed6a447
+  Firebase: 343d7539befb614d22b2eae24759f6307b1175e9
+  FirebaseAnalytics: 9a12e090ead49f8877ed8132ae920e3cbbd2fcd0
+  FirebaseCore: 9948a31ff2c6cf323f9b040068201a95d271b68d
+  FirebaseCoreInternal: b342e37cd4f5b4454ec34308f073420e7920858e
+  FirebaseInstallations: b28af1b9f997f1a799efe818c94695a3728c352f
+  GoogleAppMeasurement: 3ae505b44174bcc0775f5c86cecc5826259fbb1e
+  GoogleSignIn: b232380cf495a429b8095d3178a8d5855b42e842
+  GoogleUtilities: 13e2c67ede716b8741c7989e26893d151b2b2084
+  GTMAppAuth: 99fb010047ba3973b7026e45393f51f27ab965ae
+  GTMSessionFetcher: e8647203b65cee28c5f73d0f473d096653945e72
+  Kingfisher: 016c8b653a35add51dd34a3aba36b580041acc74
+  nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
+  Presentation: c66e877bb3e8a6437ca9c19ab018cfa4b04a98ee
+  PromisesObjC: c50d2056b5253dadbd6c2bea79b0674bd5a52fa4
+  SideMenu: f583187d21c5b1dd04c72002be544b555a2627a2
+  SkeletonView: 5a050f6411e697abd4cda0a8d767013399dccd69
+  SnapKit: e01d52ebb8ddbc333eefe2132acf85c8227d9c25
+  SwiftLint: 1cc5cd61ba9bacb2194e340aeb47a2a37fda00b3
 
-PODFILE CHECKSUM: ae0d6880f6be4b3d5daa37feb88551fed39759d0
+PODFILE CHECKSUM: 78976849d3674381df5ca101403b730495326d35
 
 COCOAPODS: 1.11.3

--- a/Uplift.xcodeproj/project.pbxproj
+++ b/Uplift.xcodeproj/project.pbxproj
@@ -37,8 +37,6 @@
 		1C7847C4216E77E30066E0DA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1C7847C3216E77E30066E0DA /* Assets.xcassets */; };
 		1CCCEB97215058C5001B3551 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 1CCCEB96215058C5001B3551 /* .swiftlint.yml */; };
 		2D50591B2986D8A400F3616C /* API.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D50591A2986D8A400F3616C /* API.swift */; };
-		2D50591D2986D8A800F3616C /* Keys.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2D50591C2986D8A800F3616C /* Keys.plist */; };
-		2D50591F2986D8AD00F3616C /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2D50591E2986D8AD00F3616C /* GoogleService-Info.plist */; };
 		2D9B3BEE29E3520400E7D93A /* ActivitiesListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D9B3BED29E3520400E7D93A /* ActivitiesListCell.swift */; };
 		2D9B3BF029E352A000E7D93A /* Activity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D9B3BEF29E352A000E7D93A /* Activity.swift */; };
 		2D9B3BF229E3569600E7D93A /* ActivityListItemCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D9B3BF129E3569600E7D93A /* ActivityListItemCell.swift */; };
@@ -101,6 +99,8 @@
 		8DD7C7732083E09A004EB196 /* OldDropdownHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DD7C7722083E09A004EB196 /* OldDropdownHeaderView.swift */; };
 		8DD7C7752083E0FB004EB196 /* DropdownViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DD7C7742083E0FB004EB196 /* DropdownViewCell.swift */; };
 		8DD7C77720844175004EB196 /* DropdownFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DD7C77620844175004EB196 /* DropdownFooterView.swift */; };
+		BFA509252A8F434200019120 /* Keys.plist in Resources */ = {isa = PBXBuildFile; fileRef = BFA509242A8F434200019120 /* Keys.plist */; };
+		BFA509292A8F435D00019120 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = BFA509282A8F435D00019120 /* GoogleService-Info.plist */; };
 		C218F937233DBE080018838A /* GymDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = C218F936233DBE080018838A /* GymDetail.swift */; };
 		C21BE14B229212AA00B5D219 /* ClassListHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21BE14A229212AA00B5D219 /* ClassListHeaderView.swift */; };
 		C21BE14D2292374400B5D219 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21BE14C2292374400B5D219 /* HomeViewController.swift */; };
@@ -220,8 +220,6 @@
 		1C7847C3216E77E30066E0DA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		1CCCEB96215058C5001B3551 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text; path = .swiftlint.yml; sourceTree = "<group>"; };
 		2D50591A2986D8A400F3616C /* API.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = API.swift; sourceTree = "<group>"; };
-		2D50591C2986D8A800F3616C /* Keys.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Keys.plist; sourceTree = "<group>"; };
-		2D50591E2986D8AD00F3616C /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		2D9B3BED29E3520400E7D93A /* ActivitiesListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivitiesListCell.swift; sourceTree = "<group>"; };
 		2D9B3BEF29E352A000E7D93A /* Activity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Activity.swift; sourceTree = "<group>"; };
 		2D9B3BF129E3569600E7D93A /* ActivityListItemCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityListItemCell.swift; sourceTree = "<group>"; };
@@ -288,6 +286,8 @@
 		8DD7C7722083E09A004EB196 /* OldDropdownHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OldDropdownHeaderView.swift; sourceTree = "<group>"; };
 		8DD7C7742083E0FB004EB196 /* DropdownViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropdownViewCell.swift; sourceTree = "<group>"; };
 		8DD7C77620844175004EB196 /* DropdownFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropdownFooterView.swift; sourceTree = "<group>"; };
+		BFA509242A8F434200019120 /* Keys.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Keys.plist; sourceTree = "<group>"; };
+		BFA509282A8F435D00019120 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		C218F936233DBE080018838A /* GymDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GymDetail.swift; sourceTree = "<group>"; };
 		C21BE14A229212AA00B5D219 /* ClassListHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClassListHeaderView.swift; sourceTree = "<group>"; };
 		C21BE14C2292374400B5D219 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
@@ -421,13 +421,6 @@
 				047ECBBE65B2C216C70CB963 /* Pods-Uplift.release.xcconfig */,
 			);
 			path = Pods;
-			sourceTree = "<group>";
-		};
-		2D19CCD2299D9B2C00EE0D16 /* Deprecated */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Deprecated;
 			sourceTree = "<group>";
 		};
 		4F27F6D5236F24C800C255D7 /* Recovered References */ = {
@@ -634,11 +627,10 @@
 		C7DFABCD204206E000545B0B /* Uplift */ = {
 			isa = PBXGroup;
 			children = (
-				2D50591E2986D8AD00F3616C /* GoogleService-Info.plist */,
+				BFA509282A8F435D00019120 /* GoogleService-Info.plist */,
 				2D50591A2986D8A400F3616C /* API.swift */,
 				C7DFABCE204206E000545B0B /* AppDelegate.swift */,
 				1C7847C3216E77E30066E0DA /* Assets.xcassets */,
-				2D19CCD2299D9B2C00EE0D16 /* Deprecated */,
 				C7DFABE22042081000545B0B /* Controllers */,
 				C75EC94E2059AC75007BC98A /* Extensions */,
 				D94BD3062159DA7D00C9214E /* graphql */,
@@ -796,7 +788,7 @@
 		E60DE89E232DA6D20022BC72 /* Secrets */ = {
 			isa = PBXGroup;
 			children = (
-				2D50591C2986D8A800F3616C /* Keys.plist */,
+				BFA509242A8F434200019120 /* Keys.plist */,
 			);
 			path = Secrets;
 			sourceTree = "<group>";
@@ -856,7 +848,6 @@
 				1CEB3B0B21503E5100BB5B61 /* Run SwiftLint */,
 				8D29EFD320431FCA005B1CC8 /* Run Fabric build */,
 				AAFB7FBA28844D1D0277D787 /* [CP] Embed Pods Frameworks */,
-				49915958B9DD93E2E137339F /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -909,6 +900,7 @@
 			files = (
 				1C46740F21617680000AEDF0 /* intructorQueries.graphql in Resources */,
 				E6028E252450E19000DAF837 /* SF-Pro-Display-Bold.otf in Resources */,
+				BFA509292A8F435D00019120 /* GoogleService-Info.plist in Resources */,
 				D94BD3082159DA9200C9214E /* classQueries.graphql in Resources */,
 				D91565C92165686400BCA466 /* tagQueries.graphql in Resources */,
 				8D26DB0B2072C31500144BFC /* Lato-Black.ttf in Resources */,
@@ -919,7 +911,6 @@
 				E6028E232450E19000DAF837 /* BebasNeue-Regular.ttf in Resources */,
 				8D6B2A19215B23DC00807544 /* gymQueries.graphql in Resources */,
 				C76A70B2205ED2E100E60CC8 /* Montserrat-Light.ttf in Resources */,
-				2D50591F2986D8AD00F3616C /* GoogleService-Info.plist in Resources */,
 				C76A70B4205ED2E900E60CC8 /* Montserrat-Medium.ttf in Resources */,
 				C7DFABD9204206E000545B0B /* LaunchScreen.storyboard in Resources */,
 				E638F20424468BCC006AE55B /* BebasNeue-Bold.ttf in Resources */,
@@ -930,7 +921,7 @@
 				1C7847C4216E77E30066E0DA /* Assets.xcassets in Resources */,
 				E6028E242450E19000DAF837 /* SF-Pro-Display-Light.otf in Resources */,
 				1CCCEB97215058C5001B3551 /* .swiftlint.yml in Resources */,
-				2D50591D2986D8A800F3616C /* Keys.plist in Resources */,
+				BFA509252A8F434200019120 /* Keys.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -965,24 +956,6 @@
 			shellPath = /bin/sh;
 			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
-		49915958B9DD93E2E137339F /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Uplift/Pods-Uplift-resources.sh",
-				"${PODS_ROOT}/GoogleSignIn/Resources/GoogleSignIn.bundle",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/GoogleSignIn.bundle",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Uplift/Pods-Uplift-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		8D29EFD320431FCA005B1CC8 /* Run Fabric build */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1010,9 +983,12 @@
 				"${BUILT_PRODUCTS_DIR}/AppAuth/AppAuth.framework",
 				"${BUILT_PRODUCTS_DIR}/AppDevAnnouncements/AppDevAnnouncements.framework",
 				"${BUILT_PRODUCTS_DIR}/Bartinter/Bartinter.framework",
-				"${BUILT_PRODUCTS_DIR}/FLEX/FLEX.framework",
+				"${BUILT_PRODUCTS_DIR}/FirebaseCore/FirebaseCore.framework",
+				"${BUILT_PRODUCTS_DIR}/FirebaseCoreInternal/FirebaseCoreInternal.framework",
+				"${BUILT_PRODUCTS_DIR}/FirebaseInstallations/FirebaseInstallations.framework",
 				"${BUILT_PRODUCTS_DIR}/GTMAppAuth/GTMAppAuth.framework",
 				"${BUILT_PRODUCTS_DIR}/GTMSessionFetcher/GTMSessionFetcher.framework",
+				"${BUILT_PRODUCTS_DIR}/GoogleSignIn/GoogleSignIn.framework",
 				"${BUILT_PRODUCTS_DIR}/GoogleUtilities/GoogleUtilities.framework",
 				"${BUILT_PRODUCTS_DIR}/Kingfisher/Kingfisher.framework",
 				"${BUILT_PRODUCTS_DIR}/Presentation/Presentation.framework",
@@ -1030,9 +1006,12 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AppAuth.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AppDevAnnouncements.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Bartinter.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FLEX.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseCore.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseCoreInternal.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FirebaseInstallations.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GTMAppAuth.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GTMSessionFetcher.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleSignIn.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GoogleUtilities.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Kingfisher.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Presentation.framework",
@@ -1298,7 +1277,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -1352,7 +1331,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -1371,13 +1350,17 @@
 				DEVELOPMENT_TEAM = ZGMCXU7X3U;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Uplift/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MARKETING_VERSION = 2.4;
 				OTHER_SWIFT_FLAGS = "$(inherited) -DDEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.cornellappdev.uplift.ios;
 				PRODUCT_NAME = Uplift;
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_VERSION = 4.2;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
@@ -1393,13 +1376,17 @@
 				DEVELOPMENT_TEAM = ZGMCXU7X3U;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Uplift/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MARKETING_VERSION = 2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cornellappdev.uplift.ios;
 				PRODUCT_MODULE_NAME = Uplift;
 				PRODUCT_NAME = Uplift;
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_VERSION = 4.2;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;

--- a/Uplift.xcodeproj/xcshareddata/xcschemes/Uplift.xcscheme
+++ b/Uplift.xcodeproj/xcshareddata/xcschemes/Uplift.xcscheme
@@ -29,17 +29,6 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "C7DFABCA204206E000545B0B"
-            BuildableName = "Uplift.app"
-            BlueprintName = "Fitness"
-            ReferencedContainer = "container:Fitness.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -61,8 +50,6 @@
             ReferencedContainer = "container:Uplift.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Uplift/AppDelegate.swift
+++ b/Uplift/AppDelegate.swift
@@ -51,7 +51,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
-        return GIDSignIn.sharedInstance().handle(url as URL?)
+        return GIDSignIn.sharedInstance.handle(url)
     }
 
     // MARK: - Onboarding

--- a/Uplift/Controllers/ClassDetailViewController.swift
+++ b/Uplift/Controllers/ClassDetailViewController.swift
@@ -131,7 +131,7 @@ class ClassDetailViewController: UIViewController {
 
         let activityVC = UIActivityViewController(activityItems: [shareText], applicationActivities: nil)
 
-        activityVC.excludedActivityTypes = [.print, .assignToContact, .openInIBooks, .addToReadingList, .markupAsPDF, .airDrop]
+        activityVC.excludedActivityTypes = [.print, .assignToContact, .openInIBooks, .addToReadingList, .airDrop]
         activityVC.popoverPresentationController?.sourceView = view
 
         self.navigationController?.present(activityVC, animated: true, completion: nil)

--- a/Uplift/Controllers/HomeViewController.swift
+++ b/Uplift/Controllers/HomeViewController.swift
@@ -8,7 +8,6 @@
 
 import Alamofire
 import AppDevAnnouncements
-import Crashlytics
 import SkeletonView
 import SnapKit
 import UIKit

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "apollo": "1.9"
+    "apollo": "^1.9.2"
   }
 }


### PR DESCRIPTION
## Overview

Updated minimum deployment to iOS 11 along with Swift 5.0. Mainly just updated the default versioning of the pods (along with the versioning in the appdev forked pods as well). 