### PR TITLE
Add capacity to Gym Detail page

### DIFF
--- a/Uplift.xcodeproj/project.pbxproj
+++ b/Uplift.xcodeproj/project.pbxproj
@@ -110,6 +110,11 @@
 		BFBEE1282AB95CC0003F264E /* OpenHours.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFBEE1272AB95CC0003F264E /* OpenHours.swift */; };
 		BFCA93D82AA657B70005D191 /* QLCapacity.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFCA93D72AA657B70005D191 /* QLCapacity.swift */; };
 		BFCA93DA2AA66B6B0005D191 /* API.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFCA93D92AA66B6B0005D191 /* API.swift */; };
+		BFDE23962AE5ED31001D484F /* GymDetailFitnessCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFDE23952AE5ED31001D484F /* GymDetailFitnessCenter.swift */; };
+		BFDE23982AE5F161001D484F /* GymDetailFitnessCenterCapacityCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFDE23972AE5F161001D484F /* GymDetailFitnessCenterCapacityCell.swift */; };
+		BFDE239A2AE5F180001D484F /* GymDetailFitnessCenterHoursCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFDE23992AE5F180001D484F /* GymDetailFitnessCenterHoursCell.swift */; };
+		BFDE239C2AE5F727001D484F /* CapacityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFDE239B2AE5F727001D484F /* CapacityView.swift */; };
+		BFDE239E2AE6220C001D484F /* Capacity.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFDE239D2AE6220C001D484F /* Capacity.swift */; };
 		C21BE14B229212AA00B5D219 /* ClassListHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21BE14A229212AA00B5D219 /* ClassListHeaderView.swift */; };
 		C21BE14D2292374400B5D219 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21BE14C2292374400B5D219 /* HomeViewController.swift */; };
 		C21BE1502292409D00B5D219 /* CheckInsListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21BE14F2292409D00B5D219 /* CheckInsListCell.swift */; };
@@ -315,6 +320,11 @@
 		BFBEE1272AB95CC0003F264E /* OpenHours.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenHours.swift; sourceTree = "<group>"; };
 		BFCA93D72AA657B70005D191 /* QLCapacity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QLCapacity.swift; sourceTree = "<group>"; };
 		BFCA93D92AA66B6B0005D191 /* API.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = API.swift; sourceTree = "<group>"; };
+		BFDE23952AE5ED31001D484F /* GymDetailFitnessCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GymDetailFitnessCenter.swift; sourceTree = "<group>"; };
+		BFDE23972AE5F161001D484F /* GymDetailFitnessCenterCapacityCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GymDetailFitnessCenterCapacityCell.swift; sourceTree = "<group>"; };
+		BFDE23992AE5F180001D484F /* GymDetailFitnessCenterHoursCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GymDetailFitnessCenterHoursCell.swift; sourceTree = "<group>"; };
+		BFDE239B2AE5F727001D484F /* CapacityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapacityView.swift; sourceTree = "<group>"; };
+		BFDE239D2AE6220C001D484F /* Capacity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Capacity.swift; sourceTree = "<group>"; };
 		C21BE14A229212AA00B5D219 /* ClassListHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClassListHeaderView.swift; sourceTree = "<group>"; };
 		C21BE14C2292374400B5D219 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		C21BE14F2292409D00B5D219 /* CheckInsListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckInsListCell.swift; sourceTree = "<group>"; };
@@ -504,6 +514,7 @@
 		7E9D6DED22961B1B0054F710 /* GymDetail */ = {
 			isa = PBXGroup;
 			children = (
+				BFDE23942AE5ED10001D484F /* FitnessCenter */,
 				BF5DAB952AE365FF00846BFD /* TabbedView */,
 				BF5DAB8B2AE0A5C600846BFD /* Hours */,
 				7EC4B797236CADD8006B67B3 /* Facilities */,
@@ -596,6 +607,17 @@
 			path = "Uplift Tests";
 			sourceTree = "<group>";
 		};
+		BFDE23942AE5ED10001D484F /* FitnessCenter */ = {
+			isa = PBXGroup;
+			children = (
+				BFDE23952AE5ED31001D484F /* GymDetailFitnessCenter.swift */,
+				BFDE23972AE5F161001D484F /* GymDetailFitnessCenterCapacityCell.swift */,
+				BFDE23992AE5F180001D484F /* GymDetailFitnessCenterHoursCell.swift */,
+				BFDE239B2AE5F727001D484F /* CapacityView.swift */,
+			);
+			path = FitnessCenter;
+			sourceTree = "<group>";
+		};
 		C21BE14922920EB200B5D219 /* ClassList */ = {
 			isa = PBXGroup;
 			children = (
@@ -661,6 +683,7 @@
 				BF9DA1002AA402790069291D /* QLOpenHours.swift */,
 				BFCA93D72AA657B70005D191 /* QLCapacity.swift */,
 				BF9DA0F82AA3EE360069291D /* FitnessCenter.swift */,
+				BFDE239D2AE6220C001D484F /* Capacity.swift */,
 				BFBEE1272AB95CC0003F264E /* OpenHours.swift */,
 				E69CE6BA23F4B41000CA83BF /* Comment.swift */,
 				C25CC31723981D6600221DC8 /* Facility.swift */,
@@ -1246,10 +1269,12 @@
 				E6C41C5F2462848E002EB402 /* SportsFilterStartTimeCollectionViewCell.swift in Sources */,
 				7EF09F13232814520057CB78 /* GymFacilitiesCell.swift in Sources */,
 				4F20383F2385F27500A30FED /* OnboardingArrowButton.swift in Sources */,
+				BFDE23982AE5F161001D484F /* GymDetailFitnessCenterCapacityCell.swift in Sources */,
 				8DC5F7B72081375D0043C9CB /* FavoritesViewController.swift in Sources */,
 				E62565BD24078CAE00EF2D0D /* LoadingCollectionHeaderView.swift in Sources */,
 				03B92038247B18B5000E0F17 /* SportsFormPlayersCollectionViewCell.swift in Sources */,
 				2DA9E6A929CB644A00EFED2B /* GymCellFooter.swift in Sources */,
+				BFDE239A2AE5F180001D484F /* GymDetailFitnessCenterHoursCell.swift in Sources */,
 				4F4CA4142383A3190002FD5F /* OnboardingView.swift in Sources */,
 				E69A8578248B3E6100490EC3 /* OnboardingLetterViewController.swift in Sources */,
 				03228DD623FDEB4600BBCF9F /* PickupGameCell.swift in Sources */,
@@ -1315,6 +1340,7 @@
 				E6DD25DC2447ABBB0023D259 /* ProfileViewController.swift in Sources */,
 				4F27F6D7236F25C000C255D7 /* MiscellaneousInfoCell.swift in Sources */,
 				BF9DA1012AA402790069291D /* QLOpenHours.swift in Sources */,
+				BFDE239C2AE5F727001D484F /* CapacityView.swift in Sources */,
 				C26236FC2290D6BF007C415D /* ClassDetailTimeCell.swift in Sources */,
 				0C97AC292276840F0086D699 /* FacilityHoursCell.swift in Sources */,
 				03C8013824106893009845E7 /* CalendarGenerator.swift in Sources */,
@@ -1327,9 +1353,11 @@
 				03B9203A247B381E000E0F17 /* PaddedTextField.swift in Sources */,
 				4F20EDEB234AE46C000B26E8 /* GymWeekCell.swift in Sources */,
 				8D03EE0B206C47D400EF83C7 /* CategoryCell.swift in Sources */,
+				BFDE23962AE5ED31001D484F /* GymDetailFitnessCenter.swift in Sources */,
 				7E2E2A85237BAE86008F600D /* HoursEmptyStateView.swift in Sources */,
 				C28801A022933B3000EC48B7 /* TodaysClassesListCell.swift in Sources */,
 				C21BE154229250B700B5D219 /* ListItemCollectionViewCell.swift in Sources */,
+				BFDE239E2AE6220C001D484F /* Capacity.swift in Sources */,
 				E6C41C5924626304002EB402 /* SportsFilterGymCollectionViewCell.swift in Sources */,
 				8D03EE11206C483500EF83C7 /* LookingForCell.swift in Sources */,
 				E689381D240F68470022B524 /* LoadingCollectionView.swift in Sources */,

--- a/Uplift/Controllers/Gym Detail/GymDetailViewController.swift
+++ b/Uplift/Controllers/Gym Detail/GymDetailViewController.swift
@@ -84,6 +84,7 @@ extension GymDetailViewController: UICollectionViewDataSource, UICollectionViewD
         case .tabbedController:
             // swiftlint:disable:next force_cast
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: GymDetailTabbedControllerCell.reuseId, for: indexPath) as! GymDetailTabbedControllerCell
+            cell.configure(fitnessCenters: gymDetail.fitnessCenters)
             return cell
         }
     }

--- a/Uplift/Extensions/UIColor+Shared.swift
+++ b/Uplift/Extensions/UIColor+Shared.swift
@@ -14,6 +14,7 @@ extension UIColor {
     @nonobjc static let accentBlue = colorFromCode(0x1395FE)
     @nonobjc static let accentClosed = colorFromCode(0xF07D7D)
     @nonobjc static let accentOpen = colorFromCode(0x64C270)
+    @nonobjc static let accentGreen = colorFromCode(0x64C270)
     @nonobjc static let accentOrange = colorFromCode(0xFE8F13)
     @nonobjc static let accentPurple = colorFromCode(0x3813FE)
     @nonobjc static let accentRed = colorFromCode(0xFE1313)

--- a/Uplift/Models/Capacity.swift
+++ b/Uplift/Models/Capacity.swift
@@ -1,0 +1,60 @@
+//
+//  Capacity.swift
+//  Uplift
+//
+//  Created by alden lamp on 10/22/23.
+//  Copyright © 2023 Cornell AppDev. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+enum CapacityStatus: String {
+    case Full
+    case Cramped
+    case Light
+
+    init (percent: Double) {
+        if percent <= 0.50 {
+            self = .Light
+        } else if percent > 0.80 {
+            self = .Full
+        } else {
+            self = .Cramped
+        }
+    }
+
+    var color: UIColor {
+        switch self {
+        case .Full:     return .accentRed
+        case .Cramped:   return .accentOrange
+        case .Light:     return .accentGreen
+        }
+    }
+
+}
+
+class Capacity {
+
+    var id: Int
+    var facilityID: Int
+    var count: Int
+    var percent: Double
+    var updated: Date
+    var status: CapacityStatus {
+        return CapacityStatus(percent: percent)
+    }
+
+    init(capacityData: QLCapacity) {
+        id = capacityData.id
+        facilityID = capacityData.facilityId
+        count = capacityData.count
+        percent = capacityData.percent
+        updated = Date.getDatetimeFromString(datetime: capacityData.updated)
+    }
+
+    func getCapacityPercentString() -> String {
+        return String.getFromPercent(value: percent)
+    }
+
+}

--- a/Uplift/Models/FitnessCenter.swift
+++ b/Uplift/Models/FitnessCenter.swift
@@ -8,31 +8,16 @@
 
 import Foundation
 
-enum CapacityStatus: String {
-    case Full
-    case Cramped
-    case Light
-
-    init (percent: Double) {
-        if percent <= 0.50 {
-            self = .Light
-        } else if percent > 0.80 {
-            self = .Full
-        } else {
-            self = .Cramped
-        }
-    }
-}
-
-struct FitnessCenter {
+class FitnessCenter {
 
     var id: Int
     var gymId: Int
     var name: String
     var imageUrl: URL?
 
-    var capacityCount: Int?
-    var capacityPercent: Double?
+//    var capacityCount: Int?
+//    var capacityPercent: Double?
+    var capacity: Capacity?
 
     var hours: OpenHours
 
@@ -41,9 +26,10 @@ struct FitnessCenter {
         imageUrl = imgUrl
         id = fitnessCenter.id
         name = fitnessCenter.name
-        capacityCount = fitnessCenter.capacity?.count
-        capacityPercent = fitnessCenter.capacity?.percent
         hours = OpenHours(openHours: fitnessCenter.hours)
+        if let capacityData = fitnessCenter.capacity {
+            capacity = Capacity(capacityData: capacityData)
+        }
     }
 
     func isOpen() -> Bool {
@@ -58,14 +44,14 @@ struct FitnessCenter {
         return hours.getHoursString()
     }
 
-    func getCapacityStatus() -> CapacityStatus? {
-        guard let percent = self.capacityPercent else { return nil }
-        return CapacityStatus(percent: percent)
-    }
-
-    func getCapacityPercent() -> String? {
-        guard let percent = self.capacityPercent else { return nil }
-        return String.getFromPercent(value: percent)
-    }
+//    func getCapacityStatus() -> CapacityStatus? {
+//        guard let percent = self.capacityPercent else { return nil }
+//        return CapacityStatus(percent: percent)
+//    }
+//
+//    func getCapacityPercent() -> String? {
+//        guard let percent = self.capacityPercent else { return nil }
+//        return String.getFromPercent(value: percent)
+//    }
 
 }

--- a/Uplift/Models/QLCapacity.swift
+++ b/Uplift/Models/QLCapacity.swift
@@ -14,14 +14,14 @@ struct QLCapacity {
     var facilityId: Int
     var count: Int
     var percent: Double
-    var updated: Date
+    var updated: String
 
     init (capacityData: AllGymsQuery.Data.Gym.Facility.Capacity) {
         id = Int(capacityData.id) ?? -1
         facilityId = capacityData.facilityId
         count = capacityData.count
         percent = capacityData.percent
-        updated = Date.getDatetimeFromString(datetime: capacityData.updated)
+        updated = capacityData.updated
     }
 
 }

--- a/Uplift/Supporting/ClientStrings.swift
+++ b/Uplift/Supporting/ClientStrings.swift
@@ -108,6 +108,7 @@ struct ClientStrings {
     }
 
     struct GymDetail {
+        static let capacitiesLabel = "CAPACITIES"
         static let closedLabel = "CLOSED"
         static let closedOnACertainDay = "Closed"
         static let facilitiesSection = "FACILITIES"

--- a/Uplift/Views/Footers/GymCellFooter.swift
+++ b/Uplift/Views/Footers/GymCellFooter.swift
@@ -36,19 +36,13 @@ class GymCellFooter: UIView {
 
         hoursLabel.text = fitnessCenter.getHoursString()
 
-        if let capacityStatus = fitnessCenter.getCapacityStatus(), let percentStr = fitnessCenter.getCapacityPercent() {
+        if let capacity = fitnessCenter.capacity {
             capacityStatusLabel.isHidden = false
             capacityCountLabel.isHidden = false
-            capacityStatusLabel.text = capacityStatus.rawValue
-            capacityCountLabel.text = "\(percentStr) full"
-            switch capacityStatus {
-            case .Light:
-                capacityStatusLabel.textColor = .accentOpen
-            case .Cramped:
-                capacityStatusLabel.textColor = .accentOrange
-            case .Full:
-                capacityStatusLabel.textColor = .accentRed
-            }
+
+            capacityStatusLabel.text = capacity.status.rawValue
+            capacityCountLabel.text = "\(capacity.getCapacityPercentString()) full"
+            capacityStatusLabel.textColor = capacity.status.color
         } else {
             capacityStatusLabel.isHidden = true
             capacityCountLabel.isHidden = true

--- a/Uplift/Views/GymDetail/FitnessCenter/CapacityView.swift
+++ b/Uplift/Views/GymDetail/FitnessCenter/CapacityView.swift
@@ -1,0 +1,73 @@
+//
+//  CapacityView.swift
+//  Uplift
+//
+//  Created by alden lamp on 10/22/23.
+//  Copyright © 2023 Cornell AppDev. All rights reserved.
+//
+
+// TODO: - Merge with Elvis's capacity View
+
+import Foundation
+import UIKit
+
+class CapacityView: UIView {
+
+    let centerLabel = {
+        let label = UILabel()
+        label.textAlignment = .center
+        label.font = ._20MontserratBold
+        return label
+    }()
+
+    private let trackLayer = {
+        let layer = CAShapeLayer()
+        layer.fillColor = UIColor.clear.cgColor
+        layer.strokeColor = UIColor.gray01.cgColor
+        layer.strokeEnd = 1.0
+        return layer
+    }()
+
+    private let progressLayer = {
+        let layer = CAShapeLayer()
+        layer.fillColor = UIColor.clear.cgColor
+        layer.lineCap = .round
+        return layer
+    }()
+
+    init (width: CGFloat, lineWidth: CGFloat) {
+        super.init(frame: .zero)
+
+        let center = CGPoint(x: width/2, y: width/2)
+        let radius = width/2 - lineWidth
+        let circularPath = UIBezierPath(arcCenter: center, radius: radius, startAngle: CGFloat(-0.5 * .pi), endAngle: CGFloat(1.5 * .pi), clockwise: true)
+
+        trackLayer.path = circularPath.cgPath
+        trackLayer.lineWidth = lineWidth
+
+        progressLayer.path = circularPath.cgPath
+        progressLayer.lineWidth = lineWidth
+
+        layer.addSublayer(trackLayer)
+        layer.addSublayer(progressLayer)
+        self.addSubview(centerLabel)
+        setupConstraints()
+    }
+
+    func setupConstraints() {
+        centerLabel.snp.makeConstraints { make in
+            make.centerX.centerY.equalToSuperview()
+        }
+    }
+
+    func configure(percent: Double, progressColor: UIColor) {
+        progressLayer.strokeEnd = percent
+        progressLayer.strokeColor = progressColor.cgColor
+        centerLabel.text = String.getFromPercent(value: percent)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+}

--- a/Uplift/Views/GymDetail/FitnessCenter/GymDetailFitnessCenter.swift
+++ b/Uplift/Views/GymDetail/FitnessCenter/GymDetailFitnessCenter.swift
@@ -66,6 +66,7 @@ class GymDetailFitnessCenter: UIViewController {
         self.fitnessCenter = fitnessCenter
         tableView.reloadData()
     }
+
 }
 
 extension GymDetailFitnessCenter: UITableViewDataSource {

--- a/Uplift/Views/GymDetail/FitnessCenter/GymDetailFitnessCenter.swift
+++ b/Uplift/Views/GymDetail/FitnessCenter/GymDetailFitnessCenter.swift
@@ -1,0 +1,97 @@
+//
+//  GymDetailFitnessCenter.swift
+//  Uplift
+//
+//  Created by alden lamp on 10/22/23.
+//  Copyright © 2023 Cornell AppDev. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+class GymDetailFitnessCenter: UIViewController {
+
+    private var tableView = {
+        let tableView = UITableView()
+
+        // Layout
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+
+        // Styling
+        tableView.backgroundColor = .clear
+        tableView.showsVerticalScrollIndicator = false
+        tableView.showsHorizontalScrollIndicator = false
+        tableView.separatorStyle = .none
+        tableView.allowsSelection = false
+
+        // Cells
+        tableView.register(GymDetailFitnessCenterCapacityCell.self, forCellReuseIdentifier: GymDetailFitnessCenterCapacityCell.reuseId)
+        tableView.register(GymDetailFitnessCenterHoursCell.self, forCellReuseIdentifier: GymDetailFitnessCenterHoursCell.reuseId)
+
+        return tableView
+    }()
+
+    private var fitnessCenter: FitnessCenter?
+
+    private var sections: [ItemType]!
+
+    private enum ItemType {
+        case capacity
+        case hours
+    }
+
+    init(fitnessCenter: FitnessCenter) {
+        super.init(nibName: nil, bundle: nil)
+        sections = [.capacity, .hours]
+        self.fitnessCenter = fitnessCenter
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        tableView.delegate = self
+        tableView.dataSource = self
+        view.addSubview(tableView)
+
+        tableView.snp.makeConstraints { make in
+            make.top.bottom.leading.trailing.equalToSuperview()
+        }
+    }
+
+    func configure(fitnessCenter: FitnessCenter) {
+        self.fitnessCenter = fitnessCenter
+        tableView.reloadData()
+    }
+}
+
+extension GymDetailFitnessCenter: UITableViewDataSource {
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return sections.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        switch sections[indexPath.row] {
+        case .capacity:
+            // swiftlint:disable:next force_cast
+            let cell = tableView.dequeueReusableCell(withIdentifier: GymDetailFitnessCenterCapacityCell.reuseId, for: indexPath) as! GymDetailFitnessCenterCapacityCell
+            if let capacityData = self.fitnessCenter?.capacity {
+                cell.configure(capacity: capacityData)
+            }
+            return cell
+        case .hours:
+            // swiftlint:disable:next force_cast
+            let cell = tableView.dequeueReusableCell(withIdentifier: GymDetailFitnessCenterHoursCell.reuseId, for: indexPath) as! GymDetailFitnessCenterHoursCell
+            return cell
+        }
+    }
+
+}
+
+extension GymDetailFitnessCenter: UITableViewDelegate {
+
+}

--- a/Uplift/Views/GymDetail/FitnessCenter/GymDetailFitnessCenterCapacityCell.swift
+++ b/Uplift/Views/GymDetail/FitnessCenter/GymDetailFitnessCenterCapacityCell.swift
@@ -1,0 +1,88 @@
+//
+//  GymDetailFitnessCenterCapacityCell.swift
+//  Uplift
+//
+//  Created by alden lamp on 10/22/23.
+//  Copyright © 2023 Cornell AppDev. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+class GymDetailFitnessCenterCapacityCell: UITableViewCell {
+
+    enum LayoutConstants {
+        static let lineWidth: CGFloat = 20
+        static let capacityCirleTopPadding = 15
+        static let lastUpdatedTopPadding = 5
+    }
+
+    let capacitiesLabel = {
+        let label = UILabel()
+        label.font = ._16MontserratBold
+        label.textColor = .primaryBlack
+        label.textAlignment = .center
+        label.text = ClientStrings.GymDetail.capacitiesLabel
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    var capacityView: CapacityView!
+    var capacityViewWidth: CGFloat!
+
+    var lastUpdatedLabel = {
+        let label = UILabel()
+        label.font = ._12MontserratMedium
+        label.textColor = .gray02
+        label.textAlignment = .center
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = "Updated: 2:30 PM"
+        return label
+    }()
+
+    static let reuseId = "GymDetailFitnessCenterCapacityCellReuseID"
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+        capacityViewWidth = self.contentView.frame.width / 2
+        capacityView = CapacityView(width: capacityViewWidth, lineWidth: LayoutConstants.lineWidth)
+        capacityView.translatesAutoresizingMaskIntoConstraints = false
+        capacityView.configure(percent: 0.7, progressColor: .accentOrange)
+
+        contentView.addSubview(capacitiesLabel)
+        contentView.addSubview(capacityView)
+        contentView.addSubview(lastUpdatedLabel)
+
+        setupConstraints()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func setupConstraints() {
+        capacitiesLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalToSuperview().offset(GymDetailConstraints.verticalPadding)
+            make.height.equalTo(GymDetailConstraints.titleLabelHeight)
+        }
+
+        capacityView.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.width.height.equalTo(capacityViewWidth)
+            make.top.equalTo(capacitiesLabel.snp.bottom).offset(LayoutConstants.capacityCirleTopPadding)
+        }
+
+        lastUpdatedLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(capacityView.snp.bottom).offset(LayoutConstants.lastUpdatedTopPadding)
+        }
+    }
+
+    func configure(capacity: Capacity) {
+        self.capacityView.configure(percent: capacity.percent, progressColor: capacity.status.color)
+        self.lastUpdatedLabel.text = "Updated: \(Date.getTimeStringFromDate(time: capacity.updated))"
+    }
+
+}

--- a/Uplift/Views/GymDetail/FitnessCenter/GymDetailFitnessCenterHoursCell.swift
+++ b/Uplift/Views/GymDetail/FitnessCenter/GymDetailFitnessCenterHoursCell.swift
@@ -1,0 +1,14 @@
+//
+//  GymDetailFitnessCenterHoursCell.swift
+//  Uplift
+//
+//  Created by alden lamp on 10/22/23.
+//  Copyright © 2023 Cornell AppDev. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+class GymDetailFitnessCenterHoursCell: UITableViewCell {
+    static let reuseId = "GymDetailFitnessCenterHoursCellReuseId"
+}

--- a/Uplift/Views/GymDetail/TabbedView/GymDetailTabbedControllerCell.swift
+++ b/Uplift/Views/GymDetail/TabbedView/GymDetailTabbedControllerCell.swift
@@ -17,22 +17,36 @@ class GymDetailTabbedControllerCell: UICollectionViewCell {
     private var control: GymDetailTabbedControl!
     private var tabbedViewContoller: TabbedViewController!
 
+    var fitnessCenters: [FitnessCenter]?
+
     override init(frame: CGRect) {
         super.init(frame: frame)
-
-        control = GymDetailTabbedControl(tabs: ["Fitness Center", "Facilities"])
-        viewControllers = [GymDetailFitnessCenterViewController(color: UIColor.green),
-                           GymDetailFitnessCenterViewController(color: UIColor.blue)]
-
-        tabbedViewContoller = TabbedViewController(tabbedControl: control, viewControllers: viewControllers)
-
-        setupViews()
-        setupConstraints()
-
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(fitnessCenters: [FitnessCenter]) {
+        if self.tabbedViewContoller != nil {
+            self.tabbedViewContoller.view.removeFromSuperview()
+        }
+
+        self.fitnessCenters = fitnessCenters
+
+        var tabs = [String]()
+        self.viewControllers = []
+
+        for fitnessCenter in fitnessCenters {
+            tabs.append(fitnessCenters.count == 1 ? "Fitness Center" : fitnessCenter.name)
+            viewControllers.append(GymDetailFitnessCenter(fitnessCenter: fitnessCenter))
+        }
+
+        control = GymDetailTabbedControl(tabs: tabs)
+        tabbedViewContoller = TabbedViewController(tabbedControl: control, viewControllers: viewControllers)
+
+        setupViews()
+        setupConstraints()
     }
 
     func setupViews() {


### PR DESCRIPTION
## Overview

This adds the main structure to the fitness center aspect of the detail page along with the view for capacities.

## Changes Made

Imma keep this description short-ish. Overall, the fitness center cell is a table view that has subcells for each section. Similar to how the detail page uses a collection view, this will use a table view to accomplish the same view style.

Some other changes include creating a capacity view (based off what Elvis previously created) along with rearranging the models to isolate the capacity class as part of the fitness center.

## Next Steps

There is probably some more cleaning up that needs to be done. After that its implementing the hours part of the fitness center table view (and potentially removing the hours from the gym cells). 

## Related PRs or Issues (delete if not applicable)

#271 
#272 